### PR TITLE
Fix incorrect Err being thrown

### DIFF
--- a/src/lib/hxConn/fan/ConnFwFuncs.fan
+++ b/src/lib/hxConn/fan/ConnFwFuncs.fan
@@ -254,7 +254,7 @@ const class ConnFwFuncs
   private static Conn toConn(Obj conn)
   {
     hx := toHxConn(conn)
-    return hx as Conn ?: classicConnErr(hx)
+    return hx as Conn ?: throw classicConnErr(hx)
   }
 
   ** Return exception to use for using classic connector


### PR DESCRIPTION
When using the classic connector framework, line 257 throws a Cast Err, instead of the error returned by classicConnErr