### PR TITLE
axon: Axon throw errors will display the value of the dis tag instead…

### DIFF
--- a/src/core/axon/fan/Errs.fan
+++ b/src/core/axon/fan/Errs.fan
@@ -75,7 +75,7 @@ const class EvalTimeoutErr : EvalErr
 @Js @NoDoc
 const class ThrowErr : EvalErr
 {
-  new make(AxonContext cx, Loc loc, Dict tags) : super(tags.toStr, cx, loc)
+  new make(AxonContext cx, Loc loc, Dict tags) : super(tags.dis, cx, loc)
   {
     this.tags = tags
   }


### PR DESCRIPTION
… of a string representation of the exception dict.