### PR TITLE
Implement Control Code Lookup using map

### DIFF
--- a/src/lib/hxPy/py/hxpy/test/test_nativebrioreader.py
+++ b/src/lib/hxPy/py/hxpy/test/test_nativebrioreader.py
@@ -7,11 +7,13 @@
 #   19 Jul 2021  Matthew Giannini  Creation
 #
 
+import inspect
 import unittest
 import random
 import sys
 import struct
 import datetime
+import time
 import numpy
 from zoneinfo import ZoneInfo
 
@@ -21,6 +23,13 @@ from hxpy.haystack import *
 
 
 class TestNativeBrioReader(unittest.TestCase):
+    
+    def setUp(self):
+        self.start_time = time.time()
+
+    def tearDown(self):
+        t = time.time() - self.start_time
+        print(f"{self.id()}: {t:.3f} sec")
 
     def test_null(self):
         data = bytes([0x00])
@@ -295,6 +304,20 @@ class TestNativeBrioReader(unittest.TestCase):
         for i, v in enumerate(vals):
             x = r._decode_varint()
             self.assertEqual(v, x)
+    
+    def test_control_speed(self):
+        data = bytes.fromhex("077fffffffff00") * 1_000_000
+        brio = NativeBrioReader(data)
+        while brio.avail() > 0:
+            value = brio.read_val()
+        self.assertEqual(value, 0x7fff_ffff)
+
+    
+    def test_timing(self):
+        for test_name, method in inspect.getmembers(self, predicate=inspect.ismethod):
+            if test_name.startswith("test_") and test_name not in ("test_timing"):
+                for _ in range(100):
+                    method()
 
 
 # TestNativeBrioReader

--- a/src/lib/hxPy/py/hxpy/test/test_nativebriowriter.py
+++ b/src/lib/hxPy/py/hxpy/test/test_nativebriowriter.py
@@ -7,20 +7,29 @@
 #   21 Jul 2021  Matthew Giannini  Creation
 #
 
-import unittest
-import io
 import datetime
+import inspect
+import io
 import struct
+import time
+import unittest
+
 import numpy
 import pandas
 import pytz
 
-from hxpy.brio import NativeBrioWriter
-from hxpy.brio import NativeBrioReader
+from hxpy.brio import NativeBrioReader, NativeBrioWriter
 from hxpy.haystack import *
 
 
 class TestNativeBrioWriter(unittest.TestCase):
+
+    def setUp(self):
+        self.start_time = time.time()
+
+    def tearDown(self):
+        t = time.time() - self.start_time
+        print(f"{self.id()}: {t:.3f} sec")
 
     def test_null(self):
         with io.BytesIO() as f:
@@ -226,6 +235,12 @@ class TestNativeBrioWriter(unittest.TestCase):
             frame = pandas.DataFrame(data=[[1,2,3], [4,5,6]])
             brio.write_val(frame)
             self.assertEqual(bytes.fromhex("183c030214ff02763014ff02763114ff02763214060001ff00060002ff00060003ff00060004ff00060005ff00060006ff003e"), bytes(f.getbuffer()))
+    
+    def test_timing(self):
+        for test_name, method in inspect.getmembers(self, predicate=inspect.ismethod):
+            if test_name.startswith("test_") and test_name not in ("test_timing"):
+                for _ in range(100):
+                    method()
 
 
 # TestNativeBrioWriter


### PR DESCRIPTION
### Refactored BRIO Control Code handing to use lookup table.

There's a tradeoff here between large and small datastructures, as I don't have 100% clarity on how it's being used. 
For small datastructures, the cost is in initing the class, for large datastructures it's in actually handling the code. I split the difference here by mapping to strings and using the getattr to call the method. This ensures the map is only initialized on module loading. To optimize for larger structures, I would build the map in the class init, and map directly to the methods.

There's one area of brittleness introduced here, which is that the map can only match exactly, so each numpy.int* type has to be listed in the map, rather than just checking for an instance of the metaclass numpy.integer.

Happy #hacktober!

* Adding dict lookup for ctrl codes

* Refactored to remove init calls to dict

* modified tests

* added better speed test

* Dict lookup for read and write

* Minimized decision tree length, added tests

* Removed commented code

---------