### PR TITLE
hxStore: changed files to pipe their contents to the backup rather then loading the entire file into memory

### DIFF
--- a/src/core/hxStore/java/BackupMonitor.java
+++ b/src/core/hxStore/java/BackupMonitor.java
@@ -305,8 +305,7 @@ public final class BackupMonitor extends FanObj
     {
       // write file into zip
       startEntry(path);
-      MemBuf buf = (MemBuf)f.readAllBuf();
-      zip.write(buf.buf, 0, buf.size);
+      f.in().pipe(SysOutStream.make(zip, new Long(4096L)));
       closeEntry();
     }
     catch (Exception e)


### PR DESCRIPTION
Files that were very large (more then what the heap could hold) were causing OutOfMemory errors when they were attempting to backup.  By piping the content, this should avoid this.

I just guessed on a 4096 buffer size.  Feel free to suggest a better one.