### PR TITLE
haystack: add safeName cehck to parseGridCols

### DIFF
--- a/src/core/haystack/fan/JsonReader.fan
+++ b/src/core/haystack/fan/JsonReader.fan
@@ -145,6 +145,7 @@ class HaysonParser : JsonParser
 
       name := colMap["name"]
       if (name == null) throw ParseErr("JSON col $i missing 'name' field: $colMap")
+      if (safeNames) name = Etc.toTagName(name)
 
       metaObj := colMap["meta"]
       if (metaObj == null) return gb.addCol(name)


### PR DESCRIPTION
A bug exists when using the 'safeNames' opt parameter.  When you attempt to use JsonReader with this option, and have underscores in front of column names, an error occurs on `gb.addCol(name, parseDict(metaMap))`.  The safeNames check inside parseDict never gets called.  

Its my hope that by adding the safeNames check inside parseGridCols this bug will be fixed.