### PR TITLE
Dockerfile and automatic image build for haxall - Complete

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -45,3 +45,5 @@
 **/docker-compose*.y*ml
 readme.md
 **/.gitattributes
+**/venv
+**/.venv

--- a/.github/workflows/publish-dockerdefault.yaml
+++ b/.github/workflows/publish-dockerdefault.yaml
@@ -1,0 +1,65 @@
+# look at fan/.github/workflows/publish.yaml as the base example for this publish file
+# Also look here: https://dev.to/ken_mwaura1/automate-docker-image-builds-and-push-to-github-registry-using-github-actions-4h20
+name: Build and Publish Docker Image to GitHub Packages
+
+on:
+  push: 
+    branches: 
+      - main
+    tags:
+      - v*
+
+env:
+  REGISTRY: ghcr.io
+  # This is equivalent to ${{ github.repository_owner }}/haxall
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-publish-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      #what is an attestation?
+      attestations: write
+
+    # I don't know whether most of the below docker Github actions should be v1, v2, v3, v4, or main... I also don't know what those mean?
+    # Maybe find some info here: https://docs.docker.com/build/ci/github-actions/
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # unsure if this bit here is neccessary, since we are using "docker compose build", not "docker compose up --build"
+      - name: Remove and stop docker compose containers
+        run: docker compose -f docker-compose.yml down
+
+      # ABOUT THIS SECTION: https://stackoverflow.com/questions/53416685/docker-compose-tagging-and-pushing
+      # ABOUT 2: https://forums.docker.com/t/docker-compose-push-multiple-services-containers-to-docker-hub/121826
+      # - name: Build Docker image with docker compose
+      #   # docker compose [-f <arg>...] [options] [COMMAND] [ARGS...]
+      #   run: docker compose -f docker-compose.yml --progress=plain build --pull --push --no-cache --tag ${{ steps.meta.outputs.tags }} --label ${{ steps.meta.outputs.labels }}
+        
+      #About Docker bake: https://docs.docker.com/reference/cli/docker/buildx/bake/#set
+      #Using github actions: https://github.com/docker/bake-action
+      - name: Build Docker image with docker bake
+        run: docker buildx bake -f docker-compose.yml --progress=plain --pull --push --no-cache --set haxall.tags="${{ steps.meta.outputs.tags }}" --set haxall.labels."${{ steps.meta.outputs.labels }}" haxall
+
+      # THIS SECTION IS NOT REQUIRED, SINCE THE ABOVE TWO SECTIONS HAVE THE --push OPTION      
+      # - name: Push Docker image
+      #   run: docker push ${{ env.REGISTRY }}/{{ env.IMAGE_NAME }}:latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # ignore files for git
+.gitattributes
 
 Thumbs.db
 .DS_Store
@@ -25,3 +26,6 @@ fan.props
 # python
 venv/
 __pycache__/
+
+# docker bind-mount
+/dbs/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,21 +10,15 @@ services:
     # These two lines are for keeping the shell open when using bash as an entrypoint. 
     stdin_open: true
     tty: true
-    # The "image" line is for telling "docker compose build" to push/publish, but since we do most of this in the 'publish-hxdefault-docker-image.yaml' file in .github/workflows, it is not necessary here, I believe?
-    # Also listed there, look at: https://stackoverflow.com/questions/53416685/docker-compose-tagging-and-pushing
-    # image: ghcr.io/haxall/haxall:latest
+    image: haxall
+    container_name: haxall_run
     build:
       context: .
       dockerfile: ./docker/Dockerfile
       args: 
-        DB_NAME: var
+        DB_NAME: haxall
       # target: devrun
     ports: 
       - "8080:8080"
     volumes:
       - ./dbs:/app/haxall/dbs
-
-  # #fantom container
-  # #using "image" pulls from GitHub Docker image registry
-  # fantom:
-  #   image: "ghcr.io/fantom-lang/fantom:latest"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+# Look at documentation for docker compose: 
+# https://docs.docker.com/compose/compose-file/build
+
+# name: hx
+
+services:
+  #main haxall application
+  #using "build" looks for a local Dockerfile
+  haxall:
+    # These two lines are for keeping the shell open when using bash as an entrypoint. 
+    stdin_open: true
+    tty: true
+    # The "image" line is for telling "docker compose build" to push/publish, but since we do most of this in the 'publish-hxdefault-docker-image.yaml' file in .github/workflows, it is not necessary here, I believe?
+    # Also listed there, look at: https://stackoverflow.com/questions/53416685/docker-compose-tagging-and-pushing
+    # image: ghcr.io/haxall/haxall:latest
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+      args: 
+        DB_NAME: var
+      # target: devrun
+    ports: 
+      - "8080:8080"
+    volumes:
+      - ./dbs:/app/haxall/dbs
+
+  # #fantom container
+  # #using "image" pulls from GitHub Docker image registry
+  # fantom:
+  #   image: "ghcr.io/fantom-lang/fantom:latest"

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,47 @@
+# Include any files or directories that you don't want to be copied to your
+# Docker container upon build (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+
+# # The following was automatically listed:
+# **/.DS_Store
+# **/__pycache__
+# **/.venv
+# **/.classpath
+# **/.dockerignore
+# **/.env
+# **/.git
+# **/.gitignore
+# **/.project
+# **/.settings
+# **/.toolstarget
+# **/.vs
+# **/.vscode
+# **/*.*proj.user
+# **/*.dbmdl
+# **/*.jfm
+# # **/bin
+# **/charts
+# **/docker-compose*
+# **/compose.y*ml
+# **/Dockerfile*
+# **/node_modules
+# **/npm-debug.log
+# **/obj
+# **/secrets.dev.yaml
+# **/values.dev.yaml
+# LICENSE
+# README.md
+
+
+# The following was listed by me:
+**/.git
+**/.gitignore
+**/.github
+**/.dockerignore
+**/Dockerfile
+**/docker-compose*.y*ml
+readme.md
+**/.gitattributes

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,9 @@
 # escape=`
 # syntax=docker/dockerfile:1
 
-#This Dockerfile installs fantom, haystack-defs, and xeto before running haxall init to create hx database named "var" 
+#This Dockerfile installs fantom, haystack-defs, and xeto before running haxall init to create hx database named "haxall" 
 #To create it along with the compose file, use the following command for testing:
-#docker compose -f .\docker-compose.yml run --rm -it -p 8082:8082 --entrypoint /bin/bash haxall
+#docker compose -f .\docker-compose.yml run --rm -it -p 8080:8080 haxall
 
 ARG JDK_VERSION=17
 
@@ -29,12 +29,7 @@ RUN LATEST_ZIPURL=$(curl -s "https://api.github.com/repos/fantom-lang/fantom/rel
   && mv fantom/fantom-* rel `
   && chmod +x rel/bin/* `
   && chmod +x rel/adm/* `
-  && rm -rf fantom && rm -f fantom.zip `
-  #download linux-x86_64 SWT
-  && curl -fsSL "https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.27-202303020300/swt-4.27-gtk-linux-x86_64.zip&mirror_id=1" -o swt.zip `
-  && unzip swt.zip -d swt `
-  && mv swt/swt.jar ./ `
-  && rm -rf swt && rm -f swt.zip
+  && rm -rf fantom && rm -f fantom.zip 
 
 ENV FAN_SUBSTITUTE=/app/rel
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,105 @@
+# escape=`
+# syntax=docker/dockerfile:1
+
+#This Dockerfile installs fantom, haystack-defs, and xeto before running haxall init to create hx database named "var" 
+#To create it along with the compose file, use the following command for testing:
+#docker compose -f .\docker-compose.yml run --rm -it -p 8082:8082 --entrypoint /bin/bash haxall
+
+ARG JDK_VERSION=17
+
+FROM eclipse-temurin:$JDK_VERSION AS base
+
+RUN set -e; `
+  export DEBIAN_FRONTEND=noninteractive `
+  && apt-get -q update `
+  && apt-get -q install -y git unzip curl sed `
+  && rm -rf /var/lib/apt/lists/* 
+
+WORKDIR /app
+ARG FAN_REL_VER=1.0.80
+
+#FANTOM SOURCE START
+# This is building fantom from source. We need to start with downloading the latest release of 
+# fantom (zipfile) because fantom is required to build fantom. 
+# huge help: https://gist.github.com/gvenzl/1386755861fb42db492276d3864a378c
+#set is a builtin shell command:https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_25
+RUN LATEST_ZIPURL=$(curl -s "https://api.github.com/repos/fantom-lang/fantom/releases/latest" | sed -Ene '/^[[:space:]]*"browser_download_url": *"(.+)"$/s//\1/p') `
+  && curl -fsSL "${LATEST_ZIPURL}" -o fantom.zip `
+  && unzip fantom.zip -d fantom `
+  && mv fantom/fantom-* rel `
+  && chmod +x rel/bin/* `
+  && chmod +x rel/adm/* `
+  && rm -rf fantom && rm -f fantom.zip `
+  #download linux-x86_64 SWT
+  && curl -fsSL "https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.27-202303020300/swt-4.27-gtk-linux-x86_64.zip&mirror_id=1" -o swt.zip `
+  && unzip swt.zip -d swt `
+  && mv swt/swt.jar ./ `
+  && rm -rf swt && rm -f swt.zip
+
+ENV FAN_SUBSTITUTE=/app/rel
+
+#Get latest fantom release
+#theoretically, this will copy the current github files (latest release) for fantom 
+#into the build without keeping all the metadata from cloning?
+RUN git clone -b master --depth 1 --single-branch https://github.com/fantom-lang/fantom fan `
+  && rm -rf fan/.git*
+
+RUN <<EOF
+  echo "\n\njdkHome=${JAVA_HOME}/\ndevHome=/app/fan/\n" >> rel/etc/build/config.props
+  echo "\n\njdkHome=${JAVA_HOME}/" >> fan/etc/build/config.props
+  rel/bin/fan fan/src/buildall.fan superclean
+  rel/bin/fan fan/src/buildall.fan superclean
+  rel/bin/fan fan/src/buildboot.fan compile
+  fan/bin/fan fan/src/buildpods.fan compile
+EOF
+
+ENV PATH $PATH:/app/fan/bin
+#FANTOM SOURCE END
+
+
+#XETO START
+# ADD git@github.com:Project-Haystack/xeto.git xeto
+RUN git clone -b master --depth 1 --single-branch https://github.com/Project-Haystack/xeto xeto `
+  && rm -rf xeto/.git*
+#XETO END
+
+
+#HAYSTACK-DEFS START
+# ADD git@github.com:Project-Haystack/haystack-defs.git haystack-defs
+RUN git clone -b master --depth 1 --single-branch https://github.com/Project-Haystack/haystack-defs haystack-defs `
+  && rm -rf haystack-defs/.git*
+WORKDIR /app/haystack-defs/
+RUN <<EOF
+  touch fan.props
+  fan src/build.fan clean compile
+EOF
+#HAYSTACK-DEFS END
+
+
+
+FROM eclipse-temurin:$JDK_VERSION AS devrun
+LABEL org.opencontainers.image.source="https://github.com/haxall/haxall"
+
+COPY --from=base /app/fan/ /opt/fan/
+COPY --from=base /app/haystack-defs/ /app/haystack-defs/
+COPY --from=base /app/xeto/ /app/xeto/
+ENV PATH $PATH:/opt/fan/bin
+
+ARG DB_NAME
+ENV DB_NAME=${DB_NAME}
+
+#HAXALL START
+COPY . /app/haxall/
+WORKDIR /app/haxall
+RUN <<EOF
+  chmod +x bin/*
+  chmod +x docker/*dockerstart.sh
+  echo "path=../haystack-defs;../xeto" > fan.props
+  fan src/build.fan clean compile
+EOF
+#HAXALL END
+
+EXPOSE 8080
+
+# This provides the default entrypoint and parameters, and can be overridden in command line with "--entrypoint" when doing docker run or docker compose run...
+CMD ["./docker/hx_dockerstart.sh" ]

--- a/docker/hx_dockerstart.sh
+++ b/docker/hx_dockerstart.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+export PATH=$PATH:/app/haxall/bin
+echo "$DB_NAME"
+
+# This volume is connected via bind-mount. The bind-mount, under volumes in the compose file, will create the folder on local system if it doesn't exist. 
+# The bind-mount is /app/haxall/dbs and locally is referred to as "dbs"
+# The following creates the bind-mount folder if it doesn't exist, and cd's into it.
+if [ -d "dbs" ]; then
+    cd dbs
+else
+    mkdir dbs
+    cd dbs
+fi
+
+
+# The following runs hx init with the given database name from build argument DB_NAME (default is "var").
+# It can be changed when doing docker compose commands like so: --build-arg DB_NAME=example
+# It is stored under an ENV variable of same name (BD_NAME) created during the dockerfile build context, and persists after. 
+if [ -d "$DB_NAME" ]; then
+    # The directory exists, but is EMPTY. 
+    if [ -z "$(ls -A "$DB_NAME")" ]; then
+        echo "$DB_NAME is empty, running hx init..."
+        fan hx init -headless "$DB_NAME"
+    # The directory exists, and is NOT empty.
+    else
+        echo "$DB_NAME already exists." && echo "If you want to modify your superuser account or the HTTP port, run the 'fan hx init' command again on the same directory, like so:" && echo "fan hx init $DB_NAME"
+    fi
+# The directory does not exist.
+else
+    echo "$DB_NAME does not exist, running hx init..."
+    fan hx init -headless "$DB_NAME"
+fi
+
+# This runs haxall after creating the database. Any errors here are likely caused by the bind-mounted database being edited on the local file system by the host. 
+# Command "hx run" needs the file location of the database (i.e. /app/haxall/dbs/$DB_NAME)
+fan hx run "$DB_NAME"


### PR DESCRIPTION
A `Dockerfile` was created and completed, in conjunction with Docker Compose. 

Using Github Workflows, it automatically builds and pushes a default image with haxall on it to the ghcr.io Github Container Repository.

The `docker-compose.yml` file can be removed later, and `.github/workflows/publish-dockerdefault.yaml` can be edited, so that it does not use compose at all, if required. 