### PR TITLE
Add percentile fold to hxMath 

### DIFF
--- a/src/lib/hxMath/fan/MathFuncs.fan
+++ b/src/lib/hxMath/fan/MathFuncs.fan
@@ -295,18 +295,17 @@ const class MathFuncs
 
 
   **
-  ** Computes the p*th* quantile of a list of numbers, according to 
-  ** the specified interpolation method. 
+  ** Computes the p*th* quantile of a list of numbers, according to the specified interpolation method. 
+  ** The value p must be a number between 0.0 to 1.0.   
   **
-  ** Supported methods
   **  - **Linear** (default): Interpolates proportionally between the two closest values
-  **  - **Nearest** (default): Rounds to the nearest data point
-  **  - **Lower** (default): Rounds to the nearest lower data point
-  **  - **Higher** (default): Rounds to the nearest higher data point
-  **  - **Midpoint** (default): Averages two nearest values
+  **  - **Nearest**: Rounds to the nearest data point
+  **  - **Lower**: Rounds to the nearest lower data point
+  **  - **Higher**: Rounds to the nearest higher data point
+  **  - **Midpoint**: Averages two nearest values
   ** 
   ** Usage: [1,2,3].fold(quantile(p, method))
-
+  **
   ** Examples:
   **   [10,10,10,25,100].fold(quantile(0.7 )) => 22 //default to linear 
   **   [10,10,10,25,100].fold(quantile(0.7, "nearest")) => 25
@@ -314,6 +313,31 @@ const class MathFuncs
   **   [10,10,10,25,100].fold(quantile(0.7, "higher")) => 25
   **   [10,10,10,25,100].fold(quantile(0.7, "linear")) => 22 //same as no arg
   **   [10,10,10,25,100].fold(quantile(0.7, "midpoint")) => 17.5
+  **
+  ** Detailed Logic: 
+  **    p: percentile (decimal 0-1)
+  **    n: list size
+  **    rank: p * (n-1) // this is the index of the percentile in your list
+  **    // if rank is an integer, return list[rank]
+  **    // if rank is not an integer, interpolate via one of the above methods (illustrated below in examples)
+  **  
+  **    [1,2,3,4,5].percentile(0.5) => 3 // rank=2 is an int so we can index[2] directly
+  **  
+  **    [10,10,10, 25, 100].percentile(0.7, method)
+  **      rank = (0.7 * 4) => 2.8 
+  **  
+  **      //adjust rank based on method
+  **      nearest =  index[3]                // => 25
+  **      lower =    index[2]                // => 10
+  **      higher =   index[3]                // => 25
+  **  
+  **      //or interpolate for these methods
+  **  
+  **      //takes the 2 closest indices and calculates midpoint
+  **      midpoint = (25-10)/2 + 10          // => 17.5
+  **  
+  **      //takes the 2 closest indices and calculates weighted average
+  **      linear =   (0.2 * 10) + (0.8 * 25) // => 22
   **
   @Axon { meta = ["foldOn":"Number", "disKey":"ui::quantile"] }
   static Obj? quantile(Number perc, Str? method := "linear") 

--- a/src/lib/hxMath/fan/MathFuncs.fan
+++ b/src/lib/hxMath/fan/MathFuncs.fan
@@ -297,50 +297,37 @@ const class MathFuncs
   **
   ** Fold a series of numbers into a percentile *sample*:
   **
+  ** 
   ** Example:
-  **   [1,3,4,7,9].fold(percentile75)
+  **   [0,25,50,75,100].fold(percentile(75  )) => 75
+  **   [0,25,50,75,100].fold(percentile(75% )) => 75
+  **   [0,25,50,75,100].fold(percentile(0.75)) => 75
   **
+  @Axon { meta = ["foldOn":"Number", "disKey":"ui::percentile"] }
+  static Obj? percentile(Number perc) 
+  {
+    if (perc > Number(1)) {perc = perc / Number(100)}
+    if (perc > Number(1)) throw Err("Number must be between 0.0-1.0 OR 1-100")
+    //this needs to return an axon::Fn equivalent to percentileCalc(_,_,perc)
+    axon::Fn wrapper := AxonContext.curAxon.evalToFunc("percentileCalc(_,_,${perc})")
+    return wrapper as axon::Fn
+  }
 
-  static Obj? percentile(Obj? val, Obj? acc, Str perc) {
+  //the above func is a wrapper which takes a number percent and calls
+  //this which does the calcs
+  @NoDoc @Axon
+  static Obj? percentileCalc(Obj? val, Obj? acc, Number perc) 
+  {
     if (val === NA.val || acc === NA.val) return NA.val
     fold := acc as NumberFold
     if (val === CoreLib.foldStart) return NumberFold()
     if (val !== CoreLib.foldEnd)  return fold.add(val)
     if (fold.isEmpty) return null
 
-    Number? out := null 
-    if (perc=="1")  out = Number(fold.percentile1,  fold.unit)
-    if (perc=="5")  out = Number(fold.percentile5,  fold.unit)
-    if (perc=="25") out = Number(fold.percentile25, fold.unit)
-    if (perc=="75") out = Number(fold.percentile75, fold.unit)
-    if (perc=="95") out = Number(fold.percentile95, fold.unit)
-    if (perc=="99") out = Number(fold.percentile99, fold.unit)
-    if (out==null) throw Err("Must be 1,5,25,75,95,99")
+    fold.perc = perc.toFloat
+    Number? out := Number(fold.percentile, fold.unit)
     return out 
   }
-
-  @Axon { meta = ["foldOn":"Number", "disKey":"ui::percentile1"] }
-  static Obj? percentile1(Obj? val, Obj? acc) { percentile(val, acc, "1") } 
-
-
-  @Axon { meta = ["foldOn":"Number", "disKey":"ui::percentile5"] }
-  static Obj? percentile5(Obj? val, Obj? acc) { percentile(val, acc, "5") } 
-
-
-  @Axon { meta = ["foldOn":"Number", "disKey":"ui::percentile25"] }
-  static Obj? percentile25(Obj? val, Obj? acc) { percentile(val, acc, "25") } 
-
-
-  @Axon { meta = ["foldOn":"Number", "disKey":"ui::percentile75"] }
-  static Obj? percentile75(Obj? val, Obj? acc) { percentile(val, acc, "75") } 
-
-
-  @Axon { meta = ["foldOn":"Number", "disKey":"ui::percentile95"] }
-  static Obj? percentile95(Obj? val, Obj? acc) { percentile(val, acc, "95") } 
-
-
-  @Axon { meta = ["foldOn":"Number", "disKey":"ui::percentile99"] }
-  static Obj? percentile99(Obj? val, Obj? acc) { percentile(val, acc, "99") } 
 
 //////////////////////////////////////////////////////////////////////////
 // Matrix

--- a/src/lib/hxMath/fan/MathFuncs.fan
+++ b/src/lib/hxMath/fan/MathFuncs.fan
@@ -4,6 +4,7 @@
 //
 // History:
 //   28 Dec 2010   Brian Frank   Creation
+//
 
 using math
 using util

--- a/src/lib/hxMath/fan/MathFuncs.fan
+++ b/src/lib/hxMath/fan/MathFuncs.fan
@@ -295,59 +295,55 @@ const class MathFuncs
 
 
   **
-  ** Computes the p*th* quantile of a list of numbers, according to the specified interpolation method. 
-  ** The value p must be a number between 0.0 to 1.0.   
+  ** Computes the p*th* quantile of a list of numbers, according to the specified interpolation method.
+  ** The value p must be a number between 0.0 to 1.0.
   **
-  **  - **Linear** (default): Interpolates proportionally between the two closest values
-  **  - **Nearest**: Rounds to the nearest data point
-  **  - **Lower**: Rounds to the nearest lower data point
-  **  - **Higher**: Rounds to the nearest higher data point
-  **  - **Midpoint**: Averages two nearest values
-  ** 
+  **  - **linear** (default): Interpolates proportionally between the two closest values
+  **  - **nearest**: Rounds to the nearest data point
+  **  - **lower**: Rounds to the nearest lower data point
+  **  - **higher**: Rounds to the nearest higher data point
+  **  - **midpoint**: Averages two nearest values
+  **
   ** Usage: [1,2,3].fold(quantile(p, method))
   **
   ** Examples:
-  **   [10,10,10,25,100].fold(quantile(0.7 )) => 22 //default to linear 
+  **   [10,10,10,25,100].fold(quantile(0.7 )) => 22 //default to linear
   **   [10,10,10,25,100].fold(quantile(0.7, "nearest")) => 25
   **   [10,10,10,25,100].fold(quantile(0.7, "lower")) => 10
   **   [10,10,10,25,100].fold(quantile(0.7, "higher")) => 25
   **   [10,10,10,25,100].fold(quantile(0.7, "linear")) => 22 //same as no arg
   **   [10,10,10,25,100].fold(quantile(0.7, "midpoint")) => 17.5
   **
-  ** Detailed Logic: 
+  ** Detailed Logic:
   **    p: percentile (decimal 0-1)
   **    n: list size
   **    rank: p * (n-1) // this is the index of the percentile in your list
   **    // if rank is an integer, return list[rank]
   **    // if rank is not an integer, interpolate via one of the above methods (illustrated below in examples)
-  **  
+  **
   **    [1,2,3,4,5].percentile(0.5) => 3 // rank=2 is an int so we can index[2] directly
-  **  
+  **
   **    [10,10,10, 25, 100].percentile(0.7, method)
-  **      rank = (0.7 * 4) => 2.8 
-  **  
+  **      rank = (0.7 * 4) => 2.8
+  **
   **      //adjust rank based on method
   **      nearest =  index[3]                // => 25
   **      lower =    index[2]                // => 10
   **      higher =   index[3]                // => 25
-  **  
+  **
   **      //or interpolate for these methods
-  **  
+  **
   **      //takes the 2 closest indices and calculates midpoint
   **      midpoint = (25-10)/2 + 10          // => 17.5
-  **  
+  **
   **      //takes the 2 closest indices and calculates weighted average
   **      linear =   (0.2 * 10) + (0.8 * 25) // => 22
   **
   @Axon { meta = ["foldOn":"Number", "disKey":"ui::quantile"] }
-  static Obj? quantile(Number perc, Str? method := "linear") 
+  static Obj? quantile(Number perc, Str? method := "linear")
   {
-    //check boundaries 
-    //if (perc == null)                         throw ArgErr("Quantile must be a number, not null")
+    //check boundaries
     if (perc < Number(0) || perc > Number(1)) throw ArgErr("Number must be between 0-1")
-
-    //default to linear method 
-    if (!["linear","nearest","higher","lower","midpoint"].contains(method)) throw ArgErr("Invalid method")
 
     //this needs to return an axon::Fn equivalent to quantileFold(_,_,perc)
     axon::Fn wrapper := AxonContext.curAxon.evalToFunc("quantileFold(_,_,${perc}, \"${method}\")")
@@ -357,7 +353,7 @@ const class MathFuncs
   //the above func is a wrapper which takes a number percent and calls
   //this which does the calcs
   @NoDoc @Axon
-  static Obj? quantileFold(Obj? val, Obj? acc, Number perc, Str method) 
+  static Obj? quantileFold(Obj? val, Obj? acc, Number perc, Str method)
   {
     if (val === NA.val || acc === NA.val) return NA.val
     fold := acc as NumberFold
@@ -366,7 +362,7 @@ const class MathFuncs
     if (fold.isEmpty)              return null
 
     Number? out := Number(fold.quantile(perc.toFloat, method), fold.unit)
-    return out 
+    return out
   }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/lib/hxMath/fan/MathFuncs.fan
+++ b/src/lib/hxMath/fan/MathFuncs.fan
@@ -4,7 +4,7 @@
 //
 // History:
 //   28 Dec 2010   Brian Frank   Creation
-//
+//   7  Nov 2024   James Gessel  Add percentile folding funcs
 
 using math
 using util
@@ -292,6 +292,55 @@ const class MathFuncs
     stdDev := (sumsq / (fold.size - 1)).sqrt
     return Number(stdDev, fold.unit)
   }
+
+
+  **
+  ** Fold a series of numbers into a percentile *sample*:
+  **
+  ** Example:
+  **   [1,3,4,7,9].fold(percentile75)
+  **
+
+  static Obj? percentile(Obj? val, Obj? acc, Str perc) {
+    if (val === NA.val || acc === NA.val) return NA.val
+    fold := acc as NumberFold
+    if (val === CoreLib.foldStart) return NumberFold()
+    if (val !== CoreLib.foldEnd)  return fold.add(val)
+    if (fold.isEmpty) return null
+
+    Number? out := null 
+    if (perc=="1")  out = Number(fold.percentile1,  fold.unit)
+    if (perc=="5")  out = Number(fold.percentile5,  fold.unit)
+    if (perc=="25") out = Number(fold.percentile25, fold.unit)
+    if (perc=="75") out = Number(fold.percentile75, fold.unit)
+    if (perc=="95") out = Number(fold.percentile95, fold.unit)
+    if (perc=="99") out = Number(fold.percentile99, fold.unit)
+    if (out==null) throw Err("Must be 1,5,25,75,95,99")
+    return out 
+  }
+
+  @Axon { meta = ["foldOn":"Number", "disKey":"ui::percentile1"] }
+  static Obj? percentile1(Obj? val, Obj? acc) { percentile(val, acc, "1") } 
+
+
+  @Axon { meta = ["foldOn":"Number", "disKey":"ui::percentile5"] }
+  static Obj? percentile5(Obj? val, Obj? acc) { percentile(val, acc, "5") } 
+
+
+  @Axon { meta = ["foldOn":"Number", "disKey":"ui::percentile25"] }
+  static Obj? percentile25(Obj? val, Obj? acc) { percentile(val, acc, "25") } 
+
+
+  @Axon { meta = ["foldOn":"Number", "disKey":"ui::percentile75"] }
+  static Obj? percentile75(Obj? val, Obj? acc) { percentile(val, acc, "75") } 
+
+
+  @Axon { meta = ["foldOn":"Number", "disKey":"ui::percentile95"] }
+  static Obj? percentile95(Obj? val, Obj? acc) { percentile(val, acc, "95") } 
+
+
+  @Axon { meta = ["foldOn":"Number", "disKey":"ui::percentile99"] }
+  static Obj? percentile99(Obj? val, Obj? acc) { percentile(val, acc, "99") } 
 
 //////////////////////////////////////////////////////////////////////////
 // Matrix

--- a/src/lib/hxMath/fan/MathFuncs.fan
+++ b/src/lib/hxMath/fan/MathFuncs.fan
@@ -298,16 +298,20 @@ const class MathFuncs
   ** Fold a series of numbers into a percentile *sample*:
   **
   ** 
-  ** Example:
+  ** Examples:
   **   [0,25,50,75,100].fold(percentile(75  )) => 75
   **   [0,25,50,75,100].fold(percentile(75% )) => 75
   **   [0,25,50,75,100].fold(percentile(0.75)) => 75
+  **   [0,25,50,75,100].fold(percentile(1))    => 1 // 1 is treated as 1%, not 100%
   **
   @Axon { meta = ["foldOn":"Number", "disKey":"ui::percentile"] }
   static Obj? percentile(Number perc) 
   {
+    // make sure number is either 0-1 or 1-100
+    // 1 defaults to 1% and not 100% 
     if (perc > Number(1)) {perc = perc / Number(100)}
     if (perc > Number(1)) throw Err("Number must be between 0.0-1.0 OR 1-100")
+
     //this needs to return an axon::Fn equivalent to percentileCalc(_,_,perc)
     axon::Fn wrapper := AxonContext.curAxon.evalToFunc("percentileCalc(_,_,${perc})")
     return wrapper as axon::Fn
@@ -321,11 +325,10 @@ const class MathFuncs
     if (val === NA.val || acc === NA.val) return NA.val
     fold := acc as NumberFold
     if (val === CoreLib.foldStart) return NumberFold()
-    if (val !== CoreLib.foldEnd)  return fold.add(val)
-    if (fold.isEmpty) return null
+    if (val !== CoreLib.foldEnd)   return fold.add(val)
+    if (fold.isEmpty)              return null
 
-    fold.perc = perc.toFloat
-    Number? out := Number(fold.percentile, fold.unit)
+    Number? out := Number(fold.percentile(perc.toFloat), fold.unit)
     return out 
   }
 

--- a/src/lib/hxMath/fan/MathFuncs.fan
+++ b/src/lib/hxMath/fan/MathFuncs.fan
@@ -308,9 +308,9 @@ const class MathFuncs
   static Obj? percentile(Number perc) 
   {
     // make sure number is either 0-1 or 1-100
-    // 1 defaults to 1% and not 100% 
-    if (perc > Number(1)) {perc = perc / Number(100)}
-    if (perc > Number(1)) throw Err("Number must be between 0.0-1.0 OR 1-100")
+    // 1 defaults to 100% and not 100% 
+    if (perc >= Number(1)) {perc = perc / Number(100)}
+    if (perc >  Number(1)) throw Err("Number must be between 0.0-1.0 OR 1-100")
 
     //this needs to return an axon::Fn equivalent to percentileCalc(_,_,perc)
     axon::Fn wrapper := AxonContext.curAxon.evalToFunc("percentileCalc(_,_,${perc})")

--- a/src/lib/hxMath/fan/NumberFold.fan
+++ b/src/lib/hxMath/fan/NumberFold.fan
@@ -57,8 +57,7 @@ internal class NumberFold
   }
 
   //percentile method 
-  Float? perc := null 
-  Float percentile() 
+  Float percentile(Float? perc) 
   {
     if (perc == null) {throw Err("Percentile must be a number")}
     if (perc < 0f || perc > 1f) { throw Err("Percentile must be between 0 and 1")}
@@ -79,9 +78,9 @@ internal class NumberFold
     } 
     else 
     {
-        a := array[k]
-        b := array[k + 1]
-        return (a * (1 - d) + b * d).toFloat
+      a := array[k]
+      b := array[k + 1]
+      return (a * (1 - d) + b * d).toFloat
     }
   }
 

--- a/src/lib/hxMath/fan/NumberFold.fan
+++ b/src/lib/hxMath/fan/NumberFold.fan
@@ -19,7 +19,7 @@ internal class NumberFold
   Int size
   FloatArray array := FloatArray.makeF8(1024)
   Unit? unit
-
+  
   @Operator Float get(Int index) { array[index] }
 
   Bool isEmpty() { size == 0 }
@@ -56,14 +56,13 @@ internal class NumberFold
     return (a+b)/2f
   }
 
-  //general percentile method 
-  sys::Float percentile(sys::Float perc) {
-    if (perc < 0f || perc > 1f) {
-        throw Err("Percentile must be between 0 and 1")
-    }
-    if (isEmpty) {
-        throw Err("NumberFold is empty")
-    }
+  //percentile method 
+  Float? perc := null 
+  Float percentile() 
+  {
+    if (perc == null) {throw Err("Percentile must be a number")}
+    if (perc < 0f || perc > 1f) { throw Err("Percentile must be between 0 and 1")}
+    if (isEmpty) { throw Err("NumberFold is empty") }
     array.sort(0..<size) //sort array 
 
     if (size == 1) { return array[0] }
@@ -73,22 +72,17 @@ internal class NumberFold
     k := i.toInt    // floor of i
     d := i - k      // diff between true i and floor Int
 
-    //return indexed perc number
-    //interpolate if needed
-    if (k >= size - 1) {
-        return array[k].toFloat
-    } else {
+    //return indexed perc number, interpolate if needed
+    if (k >= size - 1) 
+    { 
+      return array[k].toFloat 
+    } 
+    else 
+    {
         a := array[k]
         b := array[k + 1]
         return (a * (1 - d) + b * d).toFloat
     }
-}
-
-  Float percentile1() { percentile(0.01f) }
-  Float percentile5() { percentile(0.05f) }
-  Float percentile25() { percentile(0.25f) }
-  Float percentile75() { percentile(0.75f) }
-  Float percentile95() { percentile(0.95f) }
-  Float percentile99() { percentile(0.99f) }
+  }
 
 }

--- a/src/lib/hxMath/fan/NumberFold.fan
+++ b/src/lib/hxMath/fan/NumberFold.fan
@@ -4,7 +4,7 @@
 //
 // History:
 //   29 Feb 2012   Brian Frank   Creation
-//
+//   7  Nov 2024   James Gessel  Add percentile funcs
 
 using haystack
 using util
@@ -55,5 +55,40 @@ internal class NumberFold
     b := array[size/2]
     return (a+b)/2f
   }
+
+  //general percentile method 
+  sys::Float percentile(sys::Float perc) {
+    if (perc < 0f || perc > 1f) {
+        throw Err("Percentile must be between 0 and 1")
+    }
+    if (isEmpty) {
+        throw Err("NumberFold is empty")
+    }
+    array.sort(0..<size) //sort array 
+
+    if (size == 1) { return array[0] }
+
+    //get index of percentile 
+    i := perc * (size - 1).toFloat
+    k := i.toInt    // floor of i
+    d := i - k      // diff between true i and floor Int
+
+    //return indexed perc number
+    //interpolate if needed
+    if (k >= size - 1) {
+        return array[k].toFloat
+    } else {
+        a := array[k]
+        b := array[k + 1]
+        return (a * (1 - d) + b * d).toFloat
+    }
+}
+
+  Float percentile1() { percentile(0.01f) }
+  Float percentile5() { percentile(0.05f) }
+  Float percentile25() { percentile(0.25f) }
+  Float percentile75() { percentile(0.75f) }
+  Float percentile95() { percentile(0.95f) }
+  Float percentile99() { percentile(0.99f) }
 
 }

--- a/src/lib/hxMath/fan/NumberFold.fan
+++ b/src/lib/hxMath/fan/NumberFold.fan
@@ -4,6 +4,7 @@
 //
 // History:
 //   29 Feb 2012   Brian Frank   Creation
+//
 
 using haystack
 using util

--- a/src/lib/hxMath/fan/NumberFold.fan
+++ b/src/lib/hxMath/fan/NumberFold.fan
@@ -4,7 +4,6 @@
 //
 // History:
 //   29 Feb 2012   Brian Frank   Creation
-//   7  Nov 2024   James Gessel  Add percentile funcs
 
 using haystack
 using util
@@ -56,32 +55,29 @@ internal class NumberFold
     return (a+b)/2f
   }
 
-  //percentile method 
-  Float percentile(Float? perc) 
+  //quantile method 
+  //  todo 
+  //    -update median to use 'quantile' at 50% to 
+  //     take advantage of methods 
+
+  Float quantile(Float? perc, Str? method) 
   {
-    if (perc == null) {throw Err("Percentile must be a number")}
-    if (perc < 0f || perc > 1f) { throw Err("Percentile must be between 0 and 1")}
-    if (isEmpty) { throw Err("NumberFold is empty") }
-    array.sort(0..<size) //sort array 
-
+    
     if (size == 1) { return array[0] }
+    array.sort(0..<size)
 
-    //get index of percentile 
+    //get rank (index of quantile)
     i := perc * (size - 1).toFloat
     k := i.toInt    // floor of i
     d := i - k      // diff between true i and floor Int
 
-    //return indexed perc number, interpolate if needed
-    if (k >= size - 1) 
-    { 
-      return array[k].toFloat 
-    } 
-    else 
-    {
-      a := array[k]
-      b := array[k + 1]
-      return (a * (1 - d) + b * d).toFloat
-    }
+    //handle each method 
+    if      (method=="lower")    return array[k].toFloat 
+    else if (method=="higher")   return array[k+1]
+    else if (method=="nearest")  return array[i.round.toInt]
+    else if (method=="midpoint") return ((array[k] + array[(k + 1).min(size - 1)]) / 2).toFloat
+    else if (method=="linear")   return (array[k] + (array[(k + 1).min(size - 1)] - array[k]) * d).toFloat
+    else throw Err("Unexpected method type")
   }
 
 }

--- a/src/lib/hxMath/fan/NumberFold.fan
+++ b/src/lib/hxMath/fan/NumberFold.fan
@@ -19,7 +19,7 @@ internal class NumberFold
   Int size
   FloatArray array := FloatArray.makeF8(1024)
   Unit? unit
-  
+
   @Operator Float get(Int index) { array[index] }
 
   Bool isEmpty() { size == 0 }

--- a/src/lib/hxMath/fan/NumberFold.fan
+++ b/src/lib/hxMath/fan/NumberFold.fan
@@ -56,14 +56,10 @@ internal class NumberFold
     return (a+b)/2f
   }
 
-  //quantile method 
-  //  todo 
-  //    -update median to use 'quantile' at 50% to 
-  //     take advantage of methods 
-
-  Float quantile(Float? perc, Str? method) 
+  //quantile method
+  Float quantile(Float? perc, Str? method)
   {
-    
+
     if (size == 1) { return array[0] }
     array.sort(0..<size)
 
@@ -72,13 +68,15 @@ internal class NumberFold
     k := i.toInt    // floor of i
     d := i - k      // diff between true i and floor Int
 
-    //handle each method 
-    if      (method=="lower")    return array[k].toFloat 
-    else if (method=="higher")   return array[k+1]
-    else if (method=="nearest")  return array[i.round.toInt]
-    else if (method=="midpoint") return ((array[k] + array[(k + 1).min(size - 1)]) / 2).toFloat
-    else if (method=="linear")   return (array[k] + (array[(k + 1).min(size - 1)] - array[k]) * d).toFloat
-    else throw Err("Unexpected method type")
+    //handle each method
+    switch(method)
+    {
+      case "lower":    return array[k].toFloat
+      case "higher":   return array[k + 1]
+      case "nearest":  return array[i.round.toInt]
+      case "midpoint": return ((array[k] + array[(k + 1).min(size - 1)]) / 2).toFloat
+      case "linear":   return (array[k] + (array[(k + 1).min(size - 1)] - array[k]) * d).toFloat
+      default: throw Err("Unexpected method type")
+    }
   }
-
 }

--- a/src/lib/hxMath/test/MathTest.fan
+++ b/src/lib/hxMath/test/MathTest.fan
@@ -4,7 +4,7 @@
 //
 // History:
 //   28 Dec 2010   Brian Frank   Creation
-//
+//   7  Nov 2024   James Gessel  Added percentile func testing
 
 using haystack
 using hx
@@ -83,17 +83,30 @@ class MathTest : HxTest
 
     // Test cases for RMSE and MBE provided by PNL
 
-    //           list                       mean          median RMSE-0        RMSE-1        MBE-0          MBE-1
-    //           ----------------------     ------------  ------ ------        -------       -----          -----
-    verifyFolds("[]",                       null,         null,  null,         null,         null,          null)
-    verifyFolds("[na()]",                   NA.val,       NA.val,NA.val,       NA.val,       NA.val,        NA.val)
-    verifyFolds("[null]",                   null,         null,  null,         null,         null,          null)
-    verifyFolds("[2]",                      2f,           2f,    0f,           null,         0f,            null)
-    verifyFolds("[1, 4]",                   2.5f,         2.5f,  1.060660172f, 2.121320344f, 0f,            0f)
-    verifyFolds("[4, 2, 7]",                4.333333333f, 4f,    1.201850425f, 1.802775638f, 0.3333333333f, 0.5f)
-    verifyFolds("[4, na(), 7]",             NA.val,       NA.val,NA.val,       NA.val,       NA.val,        NA.val)
-    verifyFolds("[-3, 4, 10, 11, 6, 4]",    5.333333333f, 5f,    1.885618083f, 2.2627417f,   0.3333333333f, 0.4f)
-    verifyFolds("[-3, 4, 10, 2, 11, 6, 2]", 4.57142857f,  4f,    1.726149425f, 2.013840996f, 0.571428571f,  0.666666667f)
+    //           list                       mean          median   RMSE-0        RMSE-1        MBE-0          MBE-1
+    //           ----------------------     ------------  ------   ------        -------       -----          -----
+    verifyFolds("[]",                       null,         null,    null,         null,         null,          null)
+    verifyFolds("[na()]",                   NA.val,       NA.val,  NA.val,       NA.val,       NA.val,        NA.val)
+    verifyFolds("[null]",                   null,         null,    null,         null,         null,          null)
+    verifyFolds("[2]",                      2f,           2f,      0f,           null,         0f,            null)
+    verifyFolds("[1, 4]",                   2.5f,         2.5f,    1.060660172f, 2.121320344f, 0f,            0f)
+    verifyFolds("[4, 2, 7]",                4.333333333f, 4f,      1.201850425f, 1.802775638f, 0.3333333333f, 0.5f)
+    verifyFolds("[4, na(), 7]",             NA.val,       NA.val,  NA.val,       NA.val,       NA.val,        NA.val)
+    verifyFolds("[-3, 4, 10, 11, 6, 4]",    5.333333333f, 5f,      1.885618083f, 2.2627417f,   0.3333333333f, 0.4f)
+    verifyFolds("[-3, 4, 10, 2, 11, 6, 2]", 4.57142857f,  4f,      1.726149425f, 2.013840996f, 0.571428571f,  0.666666667f)
+    
+// ercentile folds                                percentile1  percentile5  percentile25  percentile75  percentile95  percentile99
+//                                                ----------  -----------  ------------  ------------  ------------  ------------
+verifyPercentileFolds("[]",                       null,       null,         null,         null,         null,         null)
+verifyPercentileFolds("[na()]",                   NA.val,     NA.val,       NA.val,       NA.val,       NA.val,       NA.val)
+verifyPercentileFolds("[null]",                   null,       null,         null,         null,         null,         null)
+verifyPercentileFolds("[1, 4]",                   1.03f,      1.15f,        1.75f,        3.25f,        3.85f,        3.97f)
+verifyPercentileFolds("[2]",                      2f,         2f,           2f,           2f,           2f,           2f)
+verifyPercentileFolds("[4, 2, 7]",                2.04f,      2.2f,         3f,           5.5f,         6.7f,         6.94f)
+verifyPercentileFolds("[4, na(), 7]",             NA.val,     NA.val,       NA.val,       NA.val,       NA.val,       NA.val)
+verifyPercentileFolds("[-3, 4, 10, 11, 6, 4]",    -2.65f,     -1.25f,       4f,           9f,           10.75f,       10.95f)
+verifyPercentileFolds("[-3, 4, 10, 2, 11, 6, 2]", -2.7f,     -1.5f,         2f,           8f,           10.7f,        10.94f)
+
   }
 
   Void verifyFolds(Str list, Obj? mean, Obj? median, Obj? rmse0, Obj? rmse1, Obj? mbe0, Obj? mbe1)
@@ -104,6 +117,16 @@ class MathTest : HxTest
     verifyFoldEq("${list}.fold(rootMeanSquareErr(_, _, 1))", rmse1)
     verifyFoldEq("${list}.fold(meanBiasErr)", mbe0)
     verifyFoldEq("${list}.fold(meanBiasErr(_,_,1))", mbe1)
+  }
+
+  Void verifyPercentileFolds(Str list, Obj? percentile1, Obj? percentile5, Obj? percentile25, Obj? percentile75, Obj? percentile95, Obj? percentile99)
+  {
+    verifyFoldEq("${list}.fold(percentile1)",  percentile1)
+    verifyFoldEq("${list}.fold(percentile5)",  percentile5)
+    verifyFoldEq("${list}.fold(percentile25)", percentile25)
+    verifyFoldEq("${list}.fold(percentile75)", percentile75)
+    verifyFoldEq("${list}.fold(percentile95)", percentile95)
+    verifyFoldEq("${list}.fold(percentile99)", percentile99)
   }
 
   Void verifyFoldEq(Str axon, Obj? expected)

--- a/src/lib/hxMath/test/MathTest.fan
+++ b/src/lib/hxMath/test/MathTest.fan
@@ -4,7 +4,7 @@
 //
 // History:
 //   28 Dec 2010   Brian Frank   Creation
-//   7  Nov 2024   James Gessel  Added percentile func testing
+//
 
 using haystack
 using hx
@@ -83,30 +83,17 @@ class MathTest : HxTest
 
     // Test cases for RMSE and MBE provided by PNL
 
-    //           list                       mean          median   RMSE-0        RMSE-1        MBE-0          MBE-1
-    //           ----------------------     ------------  ------   ------        -------       -----          -----
-    verifyFolds("[]",                       null,         null,    null,         null,         null,          null)
-    verifyFolds("[na()]",                   NA.val,       NA.val,  NA.val,       NA.val,       NA.val,        NA.val)
-    verifyFolds("[null]",                   null,         null,    null,         null,         null,          null)
-    verifyFolds("[2]",                      2f,           2f,      0f,           null,         0f,            null)
-    verifyFolds("[1, 4]",                   2.5f,         2.5f,    1.060660172f, 2.121320344f, 0f,            0f)
-    verifyFolds("[4, 2, 7]",                4.333333333f, 4f,      1.201850425f, 1.802775638f, 0.3333333333f, 0.5f)
-    verifyFolds("[4, na(), 7]",             NA.val,       NA.val,  NA.val,       NA.val,       NA.val,        NA.val)
-    verifyFolds("[-3, 4, 10, 11, 6, 4]",    5.333333333f, 5f,      1.885618083f, 2.2627417f,   0.3333333333f, 0.4f)
-    verifyFolds("[-3, 4, 10, 2, 11, 6, 2]", 4.57142857f,  4f,      1.726149425f, 2.013840996f, 0.571428571f,  0.666666667f)
-    
-// ercentile folds                                percentile1  percentile5  percentile25  percentile75  percentile95  percentile99
-//                                                ----------  -----------  ------------  ------------  ------------  ------------
-verifyPercentileFolds("[]",                       null,       null,         null,         null,         null,         null)
-verifyPercentileFolds("[na()]",                   NA.val,     NA.val,       NA.val,       NA.val,       NA.val,       NA.val)
-verifyPercentileFolds("[null]",                   null,       null,         null,         null,         null,         null)
-verifyPercentileFolds("[1, 4]",                   1.03f,      1.15f,        1.75f,        3.25f,        3.85f,        3.97f)
-verifyPercentileFolds("[2]",                      2f,         2f,           2f,           2f,           2f,           2f)
-verifyPercentileFolds("[4, 2, 7]",                2.04f,      2.2f,         3f,           5.5f,         6.7f,         6.94f)
-verifyPercentileFolds("[4, na(), 7]",             NA.val,     NA.val,       NA.val,       NA.val,       NA.val,       NA.val)
-verifyPercentileFolds("[-3, 4, 10, 11, 6, 4]",    -2.65f,     -1.25f,       4f,           9f,           10.75f,       10.95f)
-verifyPercentileFolds("[-3, 4, 10, 2, 11, 6, 2]", -2.7f,     -1.5f,         2f,           8f,           10.7f,        10.94f)
-
+    //           list                       mean          median RMSE-0        RMSE-1        MBE-0          MBE-1
+    //           ----------------------     ------------  ------ ------        -------       -----          -----
+    verifyFolds("[]",                       null,         null,  null,         null,         null,          null)
+    verifyFolds("[na()]",                   NA.val,       NA.val,NA.val,       NA.val,       NA.val,        NA.val)
+    verifyFolds("[null]",                   null,         null,  null,         null,         null,          null)
+    verifyFolds("[2]",                      2f,           2f,    0f,           null,         0f,            null)
+    verifyFolds("[1, 4]",                   2.5f,         2.5f,  1.060660172f, 2.121320344f, 0f,            0f)
+    verifyFolds("[4, 2, 7]",                4.333333333f, 4f,    1.201850425f, 1.802775638f, 0.3333333333f, 0.5f)
+    verifyFolds("[4, na(), 7]",             NA.val,       NA.val,NA.val,       NA.val,       NA.val,        NA.val)
+    verifyFolds("[-3, 4, 10, 11, 6, 4]",    5.333333333f, 5f,    1.885618083f, 2.2627417f,   0.3333333333f, 0.4f)
+    verifyFolds("[-3, 4, 10, 2, 11, 6, 2]", 4.57142857f,  4f,    1.726149425f, 2.013840996f, 0.571428571f,  0.666666667f)
   }
 
   Void verifyFolds(Str list, Obj? mean, Obj? median, Obj? rmse0, Obj? rmse1, Obj? mbe0, Obj? mbe1)
@@ -119,14 +106,36 @@ verifyPercentileFolds("[-3, 4, 10, 2, 11, 6, 2]", -2.7f,     -1.5f,         2f, 
     verifyFoldEq("${list}.fold(meanBiasErr(_,_,1))", mbe1)
   }
 
-  Void verifyPercentileFolds(Str list, Obj? percentile1, Obj? percentile5, Obj? percentile25, Obj? percentile75, Obj? percentile95, Obj? percentile99)
+  @HxRuntimeTest
+  Void testQuantileFolds() 
   {
-    verifyFoldEq("${list}.fold(percentile(${Number(0.01f)}) )",  percentile1)
-    verifyFoldEq("${list}.fold(percentile(${Number(5.0f)}) )",   percentile5 )
-    verifyFoldEq("${list}.fold(percentile(${Number(0.25f)}) )",  percentile25 )
-    verifyFoldEq("${list}.fold(percentile(${Number(0.75f)}) )",  percentile75 )
-    verifyFoldEq("${list}.fold(percentile(95%) )",               percentile95 )
-    verifyFoldEq("${list}.fold(percentile(${Number(0.99f)}) )",  percentile99 )
+    rt.libs.add("math")
+
+    // quantile folds                               quantile1_linear    quantile70_linear  quantile70_nearest  quantile70_lower    quantile70_higher    quantile70_midpoint    
+    //                                              ----------          -----------        -----------         ------------        ------------         ------------           
+    verifyQuantileFolds("[]",                       null,               null,              null,                null,              null,                null                  )
+    verifyQuantileFolds("[na()]",                   NA.val,             NA.val,            NA.val,              NA.val,            NA.val,              NA.val                )
+    verifyQuantileFolds("[null]",                   null,               null,              null,                null,              null,                null                  )
+    verifyQuantileFolds("[1, 4]",                   1.03f,              3.099999f,         4f,                  1f,                4f,                  2.5f                  )
+    verifyQuantileFolds("[2]",                      2f,                 2f,                2f,                  2f,                2f,                  2f                    )
+    verifyQuantileFolds("[4, 2, 7]",                2.04f,              5.2f,              4f,                  4f,                7f,                  5.5f                  )
+    verifyQuantileFolds("[4, na(), 7]",             NA.val,             NA.val,            NA.val,              NA.val,            NA.val,              NA.val                )
+    verifyQuantileFolds("[-3, 4, 10, 11, 6, 4]",    -2.65f,             8f,                10f,                 6f,                10f,                 8f                    )
+    verifyQuantileFolds("[-3, 4, 10, 2, 11, 6, 2]", -2.7f,              6.8f,              6f,                  6f,                10f,                 8f                    )
+    verifyQuantileFolds("[10,10,10,25,100]",        10f,                22f,               25f,                 10f,               25f,                 17.5f                 )
+  }
+
+  Void verifyQuantileFolds(Str list, Obj? quantile1_linear, Obj? quantile70_linear, Obj? quantile70_nearest, Obj? quantile70_lower, Obj? quantile70_higher, Obj? quantile70_midpoint)
+  {
+    verifyFoldEq("${list}.fold(quantile(${Number(0.01f)}) )",  quantile1_linear)
+    verifyFoldEq("${list}.fold(quantile(${Number(0.7f)}, \"linear\") )",   quantile70_linear )
+    verifyFoldEq("${list}.fold(quantile(${Number(0.7f)}, \"lower\") )",   quantile70_lower )
+    verifyFoldEq("${list}.fold(quantile(${Number(0.7f)}, \"higher\") )",   quantile70_higher )
+    verifyFoldEq("${list}.fold(quantile(${Number(0.7f)}, \"midpoint\") )",   quantile70_midpoint )
+    verifyFoldEq("${list}.fold(quantile(${Number(0.7f)}, \"nearest\") )",   quantile70_nearest )
+
+    verifyErr(axon::EvalErr#) {x := eval("[10,10,10,25,100].fold(quantile(0.7, \"notafunc\"))" )}
+    verifyErr(axon::EvalErr#) {x := eval("[10,10,10,25,100].fold(quantile)")}
   }
 
   Void verifyFoldEq(Str axon, Obj? expected)

--- a/src/lib/hxMath/test/MathTest.fan
+++ b/src/lib/hxMath/test/MathTest.fan
@@ -107,12 +107,12 @@ class MathTest : HxTest
   }
 
   @HxRuntimeTest
-  Void testQuantileFolds() 
+  Void testQuantileFolds()
   {
     rt.libs.add("math")
 
-    // quantile folds                               quantile1_linear    quantile70_linear  quantile70_nearest  quantile70_lower    quantile70_higher    quantile70_midpoint    
-    //                                              ----------          -----------        -----------         ------------        ------------         ------------           
+    // quantile folds                               quantile1_linear    quantile70_linear  quantile70_nearest  quantile70_lower    quantile70_higher    quantile70_midpoint
+    //                                              ----------          -----------        -----------         ------------        ------------         ------------
     verifyQuantileFolds("[]",                       null,               null,              null,                null,              null,                null                  )
     verifyQuantileFolds("[na()]",                   NA.val,             NA.val,            NA.val,              NA.val,            NA.val,              NA.val                )
     verifyQuantileFolds("[null]",                   null,               null,              null,                null,              null,                null                  )

--- a/src/lib/hxMath/test/MathTest.fan
+++ b/src/lib/hxMath/test/MathTest.fan
@@ -121,12 +121,12 @@ verifyPercentileFolds("[-3, 4, 10, 2, 11, 6, 2]", -2.7f,     -1.5f,         2f, 
 
   Void verifyPercentileFolds(Str list, Obj? percentile1, Obj? percentile5, Obj? percentile25, Obj? percentile75, Obj? percentile95, Obj? percentile99)
   {
-    verifyFoldEq("${list}.fold(percentile1)",  percentile1)
-    verifyFoldEq("${list}.fold(percentile5)",  percentile5)
-    verifyFoldEq("${list}.fold(percentile25)", percentile25)
-    verifyFoldEq("${list}.fold(percentile75)", percentile75)
-    verifyFoldEq("${list}.fold(percentile95)", percentile95)
-    verifyFoldEq("${list}.fold(percentile99)", percentile99)
+    verifyFoldEq("${list}.fold(percentile(${Number(0.01f)}) )",  percentile1)
+    verifyFoldEq("${list}.fold(percentile(${Number(5.0f)}) )",   percentile5 )
+    verifyFoldEq("${list}.fold(percentile(${Number(0.25f)}) )",  percentile25 )
+    verifyFoldEq("${list}.fold(percentile(${Number(0.75f)}) )",  percentile75 )
+    verifyFoldEq("${list}.fold(percentile(95%) )",               percentile95 )
+    verifyFoldEq("${list}.fold(percentile(${Number(0.99f)}) )",  percentile99 )
   }
 
   Void verifyFoldEq(Str axon, Obj? expected)


### PR DESCRIPTION
Added percentile folding func for use in axon folds. 

Examples 

```
[0,25,50,75,100].fold( percentile(75)    ) => 75
[0,25,50,75,100].fold( percentile(75%)   ) => 75
[0,25,50,75,100].fold( percentile(0.75)  ) => 75
[0,25,50,75,100].fold( percentile(1)     ) => 1 // treated as 1%, not 100%
```

MathFuncs.fan 
- **percentileCalc**   *(nodoc)*
- **percentile**          *(shortcut to percentileCalc with single % input)*

NumberFold.fan
- **percentile**           (main calcs) 

MathTest.fan
- added testing for scenarious above