### PR TITLE
folio: fix FolioFlatFile so Diff.newMod is correct when commiting

### DIFF
--- a/src/core/folio/fan/FolioFlatFile.fan
+++ b/src/core/folio/fan/FolioFlatFile.fan
@@ -168,11 +168,13 @@ const class FolioFlatFile : Folio
 
   private CommitFolioRes onCommit(Diff[] diffs, Obj? cxInfo)
   {
-
     // map diffs to commit handlers
     newMod := DateTime.nowUtc(null)
     commits := FolioFlatFileCommit[,]
-    diffs.each |diff| { commits.add(FolioFlatFileCommit(this, diff, newMod, cxInfo)) }
+    diffs.each |diff| {
+      nm := (newMod <= diff.oldMod) ? diff.oldMod + 1ms : newMod
+      commits.add(FolioFlatFileCommit(this, diff, nm, cxInfo))
+    }
 
     // verify all commits upfront and call pre-commit
     hooks := this.hooks


### PR DESCRIPTION
`FolioFlatFile` was failing `testFolio::BasicTest` because when committing, the result `Diff` sometimes did not have `newMod > oldMod`.  This PR fixes that by bumping the `newMod` by `1ms` if it matches the `oldMod`.