### PR TITLE
hxPoint: When updating the current value, if the remote device sends …

### DIFF
--- a/src/lib/hxPoint/fan/PointUtil.fan
+++ b/src/lib/hxPoint/fan/PointUtil.fan
@@ -31,7 +31,6 @@ class PointUtil
 
     // safely get unit from point's unit tag
     unit := Number.loadUnit(pt["unit"] as Str ?: "", false)
-    if (unit == null) return val
 
     // if number provided is unitless, then use point's unit
     if (num.unit == null) return Number(num.toFloat, unit)


### PR DESCRIPTION
…the curVal with a unit, then the local point record must have a matching unit.