### PR TITLE
Fix connector write coaleasing

### DIFF
--- a/src/ext/hxConn/fan/ConnPointWriteState.fan
+++ b/src/ext/hxConn/fan/ConnPointWriteState.fan
@@ -209,6 +209,9 @@ const class ConnWriteInfo
     this.extra   = extra
   }
 
+  ** Return true if the write originated from an observed `onPointWrite()` callback.
+  internal Bool isFromPointWrite() { extra == "" }
+
   ** Value to write to the remote system; might be converted from writeVal
   const Obj? val
 


### PR DESCRIPTION
An issue was found whereby connectors that use `writeMaxTime` would sometimes get their point values stuck. Please note, this issue was originally found in SkyFoundry's `connExt.pod` 3.0.29. The issue appears to also be in Haxall as well.

This fix ensures point writes are not lost and the point framework doesn't get confused regarding last value that was written.

Please note, this pull request will be marked as draft until we get some customer feedback.

I also haven't ported over the unit tests to Haxall. At the time of writing, the unit tests for `hxTest` fail with `TODO`.