### PR TITLE
Jason doc rework

### DIFF
--- a/src/tool/xetoDoc/fan/ast/DocLib.fan
+++ b/src/tool/xetoDoc/fan/ast/DocLib.fan
@@ -59,6 +59,7 @@ const class DocLib : DocPage
     obj.addNotNull("tags",      DocTag.encodeList(tags))
     obj.addNotNull("types",     DocSummary.encodeList(types))
     obj.addNotNull("globals",   DocSummary.encodeList(globals))
+    obj.addNotNull("funcs",     DocSummary.encodeList(funcs))
     obj.addNotNull("instances", DocSummary.encodeList(instances))
     obj.addNotNull("chapters",  DocSummary.encodeList(chapters))
     if (!readme.isEmpty) obj["readme"] = readme.encode
@@ -78,6 +79,7 @@ const class DocLib : DocPage
       it.meta      = DocDict.decode(obj.get("meta"))
       it.types     = DocSummary.decodeList(obj["types"])
       it.globals   = DocSummary.decodeList(obj["globals"])
+      it.funcs     = DocSummary.decodeList(obj["funcs"])
       it.instances = DocSummary.decodeList(obj["instances"])
       it.chapters  = DocSummary.decodeList(obj["chapters"])
       it.readme    = DocMarkdown.decode(obj["readme"])
@@ -92,6 +94,9 @@ const class DocLib : DocPage
 
   ** Top-level global specs defined in this library
   const DocSummary[] globals
+
+  ** Top-level function specs defined in this library
+  const DocSummary[] funcs
 
   ** Instances defined in this library
   const DocSummary[] instances
@@ -190,4 +195,3 @@ const class DocLibRef
       return make(toks[0], Version.fromStr(toks[1]))
   }
 }
-

--- a/src/tool/xetoDoc/fan/ast/DocPage.fan
+++ b/src/tool/xetoDoc/fan/ast/DocPage.fan
@@ -42,6 +42,7 @@ const mixin DocPage
       case DocPageType.lib:      return DocLib.doDecode(obj)
       case DocPageType.type:     return DocType.doDecode(obj)
       case DocPageType.global:   return DocGlobal.doDecode(obj)
+      case DocPageType.func:     return DocFunc.doDecode(obj)
       case DocPageType.instance: return DocInstance.doDecode(obj)
       case DocPageType.chapter:  return DocChapter.doDecode(obj)
       case DocPageType.search:   return DocSearch.doDecode(obj)
@@ -90,8 +91,8 @@ enum class DocPageType
   lib,
   type,
   global,
+  func,
   instance,
   chapter,
   search
 }
-

--- a/src/tool/xetoDoc/fan/ast/DocSpec.fan
+++ b/src/tool/xetoDoc/fan/ast/DocSpec.fan
@@ -213,13 +213,17 @@ const class DocGlobal : DocSpecPage
 const class DocFunc : DocSpecPage
 {
   ** Constructor
-  new make(DocLibRef lib, Str qname, FileLoc? srcLoc, DocMarkdown doc, DocDict meta, DocTypeRef type) : super(lib, qname, srcLoc, doc, meta)
+  new make(DocLibRef lib, Str qname, FileLoc? srcLoc, DocMarkdown doc, DocDict meta, DocTypeRef type, Str:DocSlot slots) : super(lib, qname, srcLoc, doc, meta)
   {
     this.type = type
+    this.slots = slots
   }
 
   ** Type of this function
   const DocTypeRef type
+
+  ** Function parameter and return slots
+  const Str:DocSlot slots
 
   ** Page type
   override DocPageType pageType() { DocPageType.func }
@@ -232,6 +236,7 @@ const class DocFunc : DocSpecPage
   {
     obj := super.encode
     obj["type"] = type.encode
+    obj.addNotNull("slots", DocSlot.encodeMap(slots))
     return obj
   }
 
@@ -244,7 +249,8 @@ const class DocFunc : DocSpecPage
     doc    := DocMarkdown.decode(obj.get("doc"))
     meta   := DocDict.decode(obj.get("meta"))
     type   := DocTypeRef.decode(obj.getChecked("type"))
-    return DocFunc(lib, qname, srcLoc, doc, meta, type)
+    slots  := DocSlot.decodeMap(obj.get("slots"))
+    return DocFunc(lib, qname, srcLoc, doc, meta, type, slots)
  }
 }
 

--- a/src/tool/xetoDoc/fan/ast/DocSpec.fan
+++ b/src/tool/xetoDoc/fan/ast/DocSpec.fan
@@ -203,6 +203,52 @@ const class DocGlobal : DocSpecPage
 }
 
 **************************************************************************
+** DocFunc
+**************************************************************************
+
+**
+** DocFunc is the documentation for a Xeto top-level function
+**
+@Js
+const class DocFunc : DocSpecPage
+{
+  ** Constructor
+  new make(DocLibRef lib, Str qname, FileLoc? srcLoc, DocMarkdown doc, DocDict meta, DocTypeRef type) : super(lib, qname, srcLoc, doc, meta)
+  {
+    this.type = type
+  }
+
+  ** Type of this function
+  const DocTypeRef type
+
+  ** Page type
+  override DocPageType pageType() { DocPageType.func }
+
+  ** URI relative to base dir to page
+  override Uri uri() { DocUtil.funcToUri(qname) }
+
+  ** Encode to a JSON object tree
+  override Str:Obj encode()
+  {
+    obj := super.encode
+    obj["type"] = type.encode
+    return obj
+  }
+
+  ** Decode from a JSON object tree
+  static DocFunc doDecode(Str:Obj obj)
+  {
+    lib    := DocLibRef.decode(obj.getChecked("lib"))
+    qname  := obj.getChecked("qname")
+    srcLoc := DocUtil.srcLocDecode(obj)
+    doc    := DocMarkdown.decode(obj.get("doc"))
+    meta   := DocDict.decode(obj.get("meta"))
+    type   := DocTypeRef.decode(obj.getChecked("type"))
+    return DocFunc(lib, qname, srcLoc, doc, meta, type)
+ }
+}
+
+**************************************************************************
 ** DocSlot
 **************************************************************************
 
@@ -307,4 +353,3 @@ const class DocSlot : DocSpec
     return obj.map |x, n| { DocSlot.decode(n, x) }
   }
 }
-

--- a/src/tool/xetoDoc/fan/compiler/GenPages.fan
+++ b/src/tool/xetoDoc/fan/compiler/GenPages.fan
@@ -37,6 +37,7 @@ internal class GenPages: Step
       case DocPageType.lib:      return genLib(entry, entry.def)
       case DocPageType.type:     return genType(entry, entry.def)
       case DocPageType.global:   return genGlobal(entry, entry.def)
+      case DocPageType.func:     return genFunc(entry, entry.def)
       case DocPageType.instance: return genInstance(entry, entry.def)
       case DocPageType.chapter:  return genChapter(entry, entry.def)
       default: throw Err(entry.pageType.name)
@@ -50,7 +51,7 @@ internal class GenPages: Step
 
   DocLib genLib(PageEntry entry, Lib x)
   {
-    DocLib
+    return DocLib
     {
       it.name      = x.name
       it.version   = x.version
@@ -60,6 +61,7 @@ internal class GenPages: Step
       it.tags      = DocUtil.genTags(ns, x)
       it.types     = summaries(typesToDoc(x))
       it.globals   = summaries(x.globals)
+      it.funcs     = summaries(x.funcs)
       it.instances = summaries(x.instances)
       it.chapters  = chapterSummaries(x)
       it.readme    = entry.readme ?: DocMarkdown.empty
@@ -149,6 +151,15 @@ internal class GenPages: Step
     meta   := genDict(x.meta)
     type   := genTypeRef(x.type)
     return DocGlobal(entry.libRef, x.qname, srcLoc, doc, meta, type)
+  }
+
+  DocFunc genFunc(PageEntry entry, Spec x)
+  {
+    srcLoc := DocUtil.srcLoc(x)
+    doc    := genSpecDoc(x)
+    meta   := genDict(x.meta)
+    type   := genTypeRef(x.type)
+    return DocFunc(entry.libRef, x.qname, srcLoc, doc, meta, type)
   }
 
   DocInstance genInstance(PageEntry entry, Dict x)
@@ -241,7 +252,7 @@ internal class GenPages: Step
 
   DocMarkdown genSpecDoc(Spec x)
   {
-    genDoc(x.meta["doc"])
+    return genDoc(x.meta["doc"])
   }
 
   DocMarkdown genDoc(Obj? doc)
@@ -252,4 +263,3 @@ internal class GenPages: Step
   }
 
 }
-

--- a/src/tool/xetoDoc/fan/compiler/GenPages.fan
+++ b/src/tool/xetoDoc/fan/compiler/GenPages.fan
@@ -159,7 +159,8 @@ internal class GenPages: Step
     doc    := genSpecDoc(x)
     meta   := genDict(x.meta)
     type   := genTypeRef(x.type)
-    return DocFunc(entry.libRef, x.qname, srcLoc, doc, meta, type)
+    slots  := genSlots(x)
+    return DocFunc(entry.libRef, x.qname, srcLoc, doc, meta, type, slots)
   }
 
   DocInstance genInstance(PageEntry entry, Dict x)
@@ -173,7 +174,8 @@ internal class GenPages: Step
   {
     // only gen effective slots for top type slots
     // or a query such as points
-    effective := spec.isType || spec.isQuery
+    // for functions, we want all slots (parameters and returns)
+    effective := spec.isType || spec.isQuery || spec.isFunc
     slots := effective ? spec.slots : spec.slotsOwn
     if (slots.isEmpty) return DocSlot.empty
 

--- a/src/tool/xetoDoc/fan/compiler/PageEntry.fan
+++ b/src/tool/xetoDoc/fan/compiler/PageEntry.fan
@@ -42,17 +42,29 @@ class PageEntry
     this.link     = DocLink(uri, dis)
   }
 
-  ** Constructor for type/global
+  ** Constructor for type/global/func
   new makeSpec(Spec x, DocPageType pageType)
   {
     this.key      = DocCompiler.key(x)
     this.def      = x
-    this.uri      = DocUtil.specToUri(x)
+    this.uri      = makeSpecUri(x, pageType)
     this.lib      = x.lib
     this.dis      = x.name
     this.pageType = pageType
     this.meta     = x.meta
     this.link     = DocLink(uri, dis)
+  }
+  
+  ** Generate URI based on spec and page type
+  private static Uri makeSpecUri(Spec x, DocPageType pageType)
+  {
+    switch (pageType)
+    {
+      case DocPageType.type:   return DocUtil.typeToUri(x.qname)
+      case DocPageType.global: return DocUtil.globalToUri(x.qname)
+      case DocPageType.func:   return DocUtil.funcToUri(x.qname)
+      default:                 return DocUtil.specToUri(x)
+    }
   }
 
   ** Constructor for instance
@@ -142,4 +154,3 @@ class PageEntry
   override Str toStr() { "$uri.toCode $dis [$pageType]" }
 
 }
-

--- a/src/tool/xetoDoc/fan/util/DocIndexer.fan
+++ b/src/tool/xetoDoc/fan/util/DocIndexer.fan
@@ -29,6 +29,7 @@ abstract class DocIndexer
       case DocPageType.lib:      addLib(page)
       case DocPageType.type:     addType(page)
       case DocPageType.global:   addGlobal(page)
+      case DocPageType.func:     addFunc(page)
       case DocPageType.instance: addInstance(page)
       case DocPageType.chapter:  addChapter(page)
       case DocPageType.search:   return
@@ -61,6 +62,12 @@ abstract class DocIndexer
   virtual Void addGlobal(DocGlobal x)
   {
     doAdd(x.uri, x.lib, DocIndexerSectionType.global, [x.qname, x.name], x.qname, x.doc)
+  }
+
+  ** Add DocFunc page to index
+  virtual Void addFunc(DocFunc x)
+  {
+    doAdd(x.uri, x.lib, DocIndexerSectionType.func, [x.qname, x.name], x.qname, x.doc)
   }
 
   ** Add DocInstance page to index
@@ -161,6 +168,7 @@ enum class DocIndexerSectionType
   lib      (0.8f),
   type     (0.7f),
   global   (0.6f),
+  func     (0.65f),
   slot     (0.1f),
   instance (0.0f),
   chapter  (1.0f),
@@ -188,4 +196,3 @@ enum class DocIndexerSectionType
   }
 
 }
-


### PR DESCRIPTION
### Overview

This PR enhances the xeto documentation generator to better handle function documentation and improve the organization of specs and functions in the generated docs. This is my first contribution to this repository, so I'm sure there will be areas that need refactoring based on your feedback and coding standards.

### Changes

- __Function documentation improvements__: Enhanced `GenPages.fan` to better process and generate documentation for Xeto function specs
- __Documentation structure__: Improved the organization of functions vs specs in the reference picker data
- __DocSpec enhancements__: Updated `DocSpec.fan` to better handle function-specific metadata and documentation
- __URI generation__: Improved URI handling for function documentation pages to avoid conflicts

### Technical Details

The changes focus on the xeto documentation tooling (`src/tool/xetoDoc/`) to provide clearer separation and better organization of function documentation versus type specifications. This should make the generated documentation more navigable and useful for developers working with Xeto functions.

### Notes

As this is my first contribution to the haxall repository, I'm sure there are areas where the code doesn't fully align with your established patterns and conventions. I'm happy to refactor based on your feedback and guidance to ensure it meets the project's standards.
