### PR TITLE
ioHttp: add @password support for secure header resolution

### DIFF
--- a/src/ext/hxIO/fan/IOFuncs.fan
+++ b/src/ext/hxIO/fan/IOFuncs.fan
@@ -971,8 +971,10 @@ const class IOFuncs
   ** The 'headers' parameter is an optional Dict of request headers.
   ** Header values may use the special ref `@password` to resolve
   ** a secret from the project's password store.  The password is
-  ** looked up by the key "<scheme>://<host>[:<port>]/ <header-name>".  If the
-  ** password is not found, an exception is raised.
+  ** looked up by the key "<scheme>://<host>[:<port>]/ <header-name>".
+  **
+  ** The password key is case sensitive.  If the password is not
+  ** found, an exception is raised.
   **
   ** The 'body' parameter is any value accepted as an
   ** [I/O handle]`doc#handles` (Str, Buf, Uri, etc).  If non-null, it is
@@ -1011,14 +1013,14 @@ const class IOFuncs
       headers?.each |v, n|
       {
         ref := v as Ref
-        if (ref != null && ref.id == "password")
+        if (ref != null)
         {
-          portStr := uri.port != null ? ":${uri.port}" : ""
-          pwKey := "${uri.scheme}://${uri.host}${portStr}/ $n"
+          if (ref.id != "password") throw Err("Unsupported header ref: @$ref.id")
+          pwKey := "${uri.scheme}://${uri.auth}/ $n"
           pw := cx.db.passwords.get(pwKey) ?: throw Err("Password not found: $pwKey")
           c.reqHeaders[n] = pw
         }
-        else c.reqHeaders[n] = v.toStr
+        else c.reqHeaders[n] = (Str)v
       }
       if (body != null)
       {

--- a/src/ext/hxIO/fan/IOFuncs.fan
+++ b/src/ext/hxIO/fan/IOFuncs.fan
@@ -969,6 +969,11 @@ const class IOFuncs
   ** The connection is guaranteed to be closed when the callback returns.
   **
   ** The 'headers' parameter is an optional Dict of request headers.
+  ** Header values may use the special ref `@password` to resolve
+  ** a secret from the project's password store.  The password is
+  ** looked up by the key "<scheme>://<host>[:<port>]/ <header-name>".  If the
+  ** password is not found, an exception is raised.
+  **
   ** The 'body' parameter is any value accepted as an
   ** [I/O handle]`doc#handles` (Str, Buf, Uri, etc).  If non-null, it is
   ** streamed as the request body; Content-Type defaults to
@@ -989,6 +994,12 @@ const class IOFuncs
   **     {"Content-Type": "text/plain"}, "hello world",
   **     (code, headers, body) => {code: code, body: ioReadStr(body)})
   **
+  **   // Use password store for auth header
+  **   passwordSet("https://acme.com/ Secret-Header", "pass")
+  **   ioHttp(`https://acme.com/api`, "POST",
+  **     {"Secret-Header": @password}, body,
+  **     (code, headers, body) => {code: code, body: ioReadStr(body)})
+  **
   @Api @Axon { admin = true }
   static Obj? ioHttp(Uri uri, Str method, Dict? headers, Obj? body, Fn fn)
   {
@@ -997,7 +1008,18 @@ const class IOFuncs
     try
     {
       c.reqMethod = method.upper
-      headers?.each |v, n| { c.reqHeaders[n] = v.toStr }
+      headers?.each |v, n|
+      {
+        ref := v as Ref
+        if (ref != null && ref.id == "password")
+        {
+          portStr := uri.port != null ? ":${uri.port}" : ""
+          pwKey := "${uri.scheme}://${uri.host}${portStr}/ $n"
+          pw := cx.db.passwords.get(pwKey) ?: throw Err("Password not found: $pwKey")
+          c.reqHeaders[n] = pw
+        }
+        else c.reqHeaders[n] = v.toStr
+      }
       if (body != null)
       {
         bodyBuf := toHandle(body).inToBuf

--- a/src/ext/hxIO/test/HttpTest.fan
+++ b/src/ext/hxIO/test/HttpTest.fan
@@ -63,6 +63,15 @@ class HttpTest : HxTest
 
       // response body via ioReadStr
       verifyHttp(`/echo`, "GET", null, null, "str", 200)
+
+      // password header resolution
+      eval("""passwordSet("http://localhost:$port/ X-Secret", "my-secret-value")""")
+      Dict pwRes := eval("""ioHttp(`http://localhost:$port/echo`, "GET", {"X-Secret": @password}, null, (code, headers, body) => {code: code, body: ioReadStr(body)})""")
+      verifyEq(pwRes["code"], n(200))
+      verify(pwRes["body"].toStr.contains("x-secret=my-secret-value"))
+
+      // password not found throws error
+      verifyEvalErr("""ioHttp(`http://localhost:$port/echo`, "GET", {"X-Missing": @password}, null, (code, headers, body) => "ok")""", Err#)
     }
     finally stopServer
   }
@@ -87,7 +96,7 @@ class HttpTest : HxTest
 // Verify
 //////////////////////////////////////////////////////////////////////////
 
-  Void verifyHttp(Uri path, Str method, [Str:Str]? headers, Obj? body, Str? resReader, Int code := 200)
+  Void verifyHttp(Uri path, Str method, [Str:Obj]? headers, Obj? body, Str? resReader, Int code := 200)
   {
     uri := "http://localhost:$port" + path.toStr
     hExpr := toHeadersExpr(headers)
@@ -116,14 +125,15 @@ class HttpTest : HxTest
     }
   }
 
-  private Str toHeadersExpr([Str:Str]? headers)
+  private Str toHeadersExpr([Str:Obj]? headers)
   {
     if (headers == null) return "null"
     pairs := StrBuf()
     headers.each |v, k|
     {
       if (pairs.size > 0) pairs.add(", ")
-      pairs.add("\"$k\": \"$v\"")
+      if (v is Ref) pairs.add("\"$k\": @${(v as Ref).id}")
+      else pairs.add("\"$k\": \"$v\"")
     }
     return "{$pairs}"
   }
@@ -188,12 +198,15 @@ internal const class EchoMod : WebMod
       }
     }
 
+    xs := req.headers["X-Secret"]
+
     res.headers["Content-Type"] = "text/plain"
     res.headers["X-Echo-Test"] = "active"
     out := res.out
     out.print("method=$req.method\n")
     if (ct != null) out.print("content-type=$ct\n")
     if (cl != null) out.print("content-length=$cl\n")
+    if (xs != null) out.print("x-secret=$xs\n")
     if (body.size > 0) out.print("body=$body\n")
     out.close
   }

--- a/src/ext/hxIO/test/HttpTest.fan
+++ b/src/ext/hxIO/test/HttpTest.fan
@@ -72,6 +72,9 @@ class HttpTest : HxTest
 
       // password not found throws error
       verifyEvalErr("""ioHttp(`http://localhost:$port/echo`, "GET", {"X-Missing": @password}, null, (code, headers, body) => "ok")""", Err#)
+
+      // unsupported ref throws error
+      verifyEvalErr("""ioHttp(`http://localhost:$port/echo`, "GET", {"X-Bad": @badRef}, null, (code, headers, body) => "ok")""", Err#)
     }
     finally stopServer
   }

--- a/src/xeto/hx.io/funcs.xeto
+++ b/src/xeto/hx.io/funcs.xeto
@@ -434,6 +434,11 @@
   // The connection is guaranteed to be closed when the callback returns.
   //
   // The `headers` parameter is an optional Dict of request headers.
+  // Header values may use the special ref `@password` to resolve
+  // a secret from the project's password store.  The password is
+  // looked up by the key "<scheme>://<host>[:<port>]/ <header-name>".  If the
+  // password is not found, an exception is raised.
+  //
   // The `body` parameter is any value accepted as an
   // [I/O handle](doc#io-handles) (Str, Buf, Uri, etc).  If non-null, it is
   // streamed as the request body; Content-Type defaults to
@@ -454,6 +459,15 @@
   //     ioHttp(`http://example.com/api`, "POST",
   //       {"Content-Type": "text/plain"}, "hello world",
   //       (code, headers, body) => {code: code, body: ioReadStr(body)})
+  //
+  //     // Optionally use the password store for auth header
+  //     passwordSet("https://acme.com/ Secret-Header", "pass")
+  //
+  //     // Reference that password in the headers
+  //     ioHttp(`https://acme.com/api`, "POST",
+  //       {"Secret-Header": @password, "Content-Type": "application/json; charset=utf-8"},
+  //       body,
+  //       (code, headers, body) => {code: code, body: ioReadJson(body)})
   ioHttp: Func <admin> { uri: Uri, method: Str, headers: Dict?, body: Obj?, fn: Func, returns: Obj? }
 
 }

--- a/src/xeto/hx.io/funcs.xeto
+++ b/src/xeto/hx.io/funcs.xeto
@@ -436,8 +436,10 @@
   // The `headers` parameter is an optional Dict of request headers.
   // Header values may use the special ref `@password` to resolve
   // a secret from the project's password store.  The password is
-  // looked up by the key "<scheme>://<host>[:<port>]/ <header-name>".  If the
-  // password is not found, an exception is raised.
+  // looked up by the key "<scheme>://<host>[:<port>]/ <header-name>".
+  //
+  // The password key is case sensitive.  If the password is not
+  // found, an exception is raised.
   //
   // The `body` parameter is any value accepted as an
   // [I/O handle](doc#io-handles) (Str, Buf, Uri, etc).  If non-null, it is


### PR DESCRIPTION
Adds `@password` ref support to `ioHttp` headers. When a header value is `@password`, the secret is resolved from the project's password store using the key `<scheme>://<host>[:<port>]/ <header-name>`. Throws if the password is not found.

**Changes:**
- `IOFuncs.fan` — resolve `@password` refs in header values via `cx.db.passwords`
- `HttpTest.fan` — tests for password resolution (success + not-found error)
- `funcs.xeto` — updated docs with `@password` description and example

**Tests:** 21 verifies pass (3 new for password feature)