### PR TITLE
hxd: add -authLocal flag for loopback-only auto-login

### DIFF
--- a/src/core/hxd/fan/HxdBoot.fan
+++ b/src/core/hxd/fan/HxdBoot.fan
@@ -171,6 +171,9 @@ internal class RunCli : HxCli
   @Opt { help = "Disable authentication and use superuser for all access" }
   Bool noAuth
 
+  @Opt { help = "Auto-login superuser for requests from loopback (127.0.0.1)" }
+  Bool authLocal
+
   @Arg { help = "Runtime database directory" }
   File? dir
 
@@ -178,6 +181,7 @@ internal class RunCli : HxCli
   {
     boot := HxdBoot("sys", dir)
     if (noAuth) boot.sysConfig["noAuth"] = Marker.val
+    if (authLocal) boot.sysConfig["authLocal"] = Marker.val
     return boot.run
   }
 }

--- a/src/core/hxd/fan/user/HxdUserAuth.fan
+++ b/src/core/hxd/fan/user/HxdUserAuth.fan
@@ -115,6 +115,10 @@ internal class HxdUserAuth
     if (ext.noAuth)
       return ext.login(req, res, HxUser(rt.db.read(Filter("user and userRole==\"su\""))))
 
+    // auto login superuser for loopback-only requests
+    if (ext.authLocal && req.remoteAddr.isLoopback)
+      return ext.login(req, res, HxUser(rt.db.read(Filter("user and userRole==\"su\""))))
+
     // redirect to login
     return null
   }

--- a/src/core/hxd/fan/user/HxdUserExt.fan
+++ b/src/core/hxd/fan/user/HxdUserExt.fan
@@ -33,6 +33,9 @@ const class HxdUserExt : ExtObj, IUserExt
   ** Auto login a configured superuser account for testing
   const Bool noAuth := sys.config.has("noAuth")
 
+  ** Auto login superuser for loopback-only requests
+  const Bool authLocal := sys.config.has("authLocal")
+
   ** URI for login page
   const Uri loginUri := web.uri + `login`
 

--- a/src/core/hxm/fan/HxBoot.fan
+++ b/src/core/hxm/fan/HxBoot.fan
@@ -119,6 +119,7 @@ abstract class HxBoot
   **   - test: Marker for HxTest runtime
   **   - safeMode: Marker to disable all project extensions
   **   - noAuth: Marker to disable authentication and use superuser
+  **   - authLocal: Marker to auto-login superuser for loopback requests only
   **   - apiExtWeb: qname for ApiExt ExtWeb class
   **   - platformSpi: qname for hxPlatform::PlatformSpi class
   **   - platformNetworkSpi: qname for hxPlatformNetwork::PlatformNetworkSpi class
@@ -148,6 +149,9 @@ abstract class HxBoot
 
   ** Lookup sysConfig noAuth flag
   Bool isNoAuth() { sysConfigGet("noAuth") != null }
+
+  ** Lookup sysConfig authLocal flag
+  Bool isAuthLocal() { sysConfigGet("authLocal") != null }
 
   ** Lookup sysConfig safeMode flag
   Bool isSafeMode() { sysConfigGet("safeMode") != null }
@@ -211,6 +215,13 @@ abstract class HxBoot
     {
       echo("##")
       echo("## NO AUTH - authentication is disabled!!!!")
+      echo("##")
+    }
+
+    if (isAuthLocal)
+    {
+      echo("##")
+      echo("## AUTH LOCAL - authentication restricted to loopback only")
       echo("##")
     }
 


### PR DESCRIPTION
Adds a new `-authLocal` flag to `hxd run` as a safer alternative to `-noAuth` for local desktop deployments.

When set, requests from 127.0.0.1 are automatically authenticated as the superuser. All other IPs continue through the normal authentication pipeline. `-noAuth` is completely untouched.

Changes:
- `HxBoot`: document `authLocal` sysConfig key, add `isAuthLocal()` accessor, add startup warning in `initSysConfig()`
- `RunCli`: add `@Opt Bool authLocal` flag, wire to sysConfig
- `HxdUserExt`: add `const Bool authLocal` field
- `HxdUserAuth.checkAuthorization()`: check `authLocal && req.remoteAddr.isLoopback` before redirecting to login