### PR TITLE
hx.repo: [feat] add hx.repo lib with libRepos() axon function

### DIFF
--- a/src/ext/build.fan
+++ b/src/ext/build.fan
@@ -27,6 +27,7 @@ class Build : BuildGroup
       `hxPoint/build.fan`,
       `hxConn/build.fan`,
       `hxShell/build.fan`,
+      `hxRepo/build.fan`,
       `hxXml/build.fan`,
       `hxDocker/build.fan`,
       `hxPy/build.fan`,

--- a/src/ext/hxRepo/build.fan
+++ b/src/ext/hxRepo/build.fan
@@ -1,23 +1,23 @@
 #! /usr/bin/env fan
 //
-// Copyright (c) 2021, SkyFoundry LLC
+// Copyright (c) 2026, SkyFoundry LLC
 // Licensed under the Academic Free License version 3.0
 //
 // History:
-//   20 May 2021   Brian Frank  Creation
+//   3 May 2026  Trevor Adelman  Creation
 //
 
 using build
 
 **
-** Build: testHx
+** Build: hxRepo
 **
 class Build : BuildPod
 {
   new make()
   {
-    podName = "testHx"
-    summary = "Tests for Haxall runtime"
+    podName = "hxRepo"
+    summary = "Remote repository management"
     meta    = ["org.name":     "SkyFoundry",
                "org.uri":      "https://skyfoundry.com/",
                "proj.name":    "Haxall",
@@ -26,24 +26,12 @@ class Build : BuildPod
                "vcs.name":     "Git",
                "vcs.uri":      "https://github.com/haxall/haxall"]
     depends = ["sys @{fan.depend}",
-               "concurrent @{fan.depend}",
-               "inet @{fan.depend}",
                "xeto @{hx.depend}",
                "xetom @{hx.depend}",
                "haystack @{hx.depend}",
-               "auth @{hx.depend}",
                "axon @{hx.depend}",
-               "obs @{hx.depend}",
-               "folio @{hx.depend}",
-               "hx @{hx.depend}",
-               "hxm @{hx.depend}",
-               "hxd @{hx.depend}",
-               "hxFolio @{hx.depend}",
-               "hxConn @{hx.depend}",
-               "hxRepo @{hx.depend}"]
+               "hx @{hx.depend}"]
     srcDirs = [`fan/`]
-    resDirs = [`lib/`, `lib/connTest/`]
-    index =   ["xeto.bindings":["hx.test", "hx.test.conn"], "ph.lib":"connTest" ]
+    index   = ["xeto.bindings":"hx.repo"]
   }
 }
-

--- a/src/ext/hxRepo/build.fan
+++ b/src/ext/hxRepo/build.fan
@@ -17,7 +17,7 @@ class Build : BuildPod
   new make()
   {
     podName = "hxRepo"
-    summary = "Remote repository management"
+    summary = "Xeto remote repo management and installation"
     meta    = ["org.name":     "SkyFoundry",
                "org.uri":      "https://skyfoundry.com/",
                "proj.name":    "Haxall",

--- a/src/ext/hxRepo/fan/RepoFuncs.fan
+++ b/src/ext/hxRepo/fan/RepoFuncs.fan
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2026, SkyFoundry LLC
+// Licensed under the Academic Free License version 3.0
+//
+// History:
+//   3 May 2026  Trevor Adelman  Creation
+//
+
+using xeto
+using haystack
+using axon
+using hx
+
+**
+** Axon functions for remote repository management
+**
+const class RepoFuncs
+{
+
+  **
+  ** List configured remote repos as a grid.  The result grid
+  ** includes the following columns:
+  **   - 'name': programmatic name of the repo
+  **   - 'uri': URI endpoint for the repo
+  **   - 'authToken': env var name if auth token is configured
+  **
+  ** Examples:
+  **   libRepos()
+  **
+  @Api @Axon { admin = true }
+  static Grid libRepos()
+  {
+    cx := Context.cur
+    repos := cx.rt.ns.env.remoteRepos.list
+
+    gb := GridBuilder()
+    gb.addCol("name").addCol("uri").addCol("authToken")
+    repos.each |r|
+    {
+      gb.addRow([r.name, r.uri, r.authTokenEnvName])
+    }
+    return gb.toGrid
+  }
+
+}

--- a/src/ext/hxRepo/fan/RepoFuncs.fan
+++ b/src/ext/hxRepo/fan/RepoFuncs.fan
@@ -12,21 +12,11 @@ using axon
 using hx
 
 **
-** Axon functions for remote repository management
+** Axon functions for xeto remote repo management and installation
 **
 const class RepoFuncs
 {
 
-  **
-  ** List configured remote repos as a grid.  The result grid
-  ** includes the following columns:
-  **   - 'name': programmatic name of the repo
-  **   - 'uri': URI endpoint for the repo
-  **   - 'authToken': env var name if auth token is configured
-  **
-  ** Examples:
-  **   libRepos()
-  **
   @Api @Axon { admin = true }
   static Grid libRepos()
   {

--- a/src/test/testHx/fan/RepoFuncsTest.fan
+++ b/src/test/testHx/fan/RepoFuncsTest.fan
@@ -1,0 +1,40 @@
+//
+// Copyright (c) 2026, SkyFoundry LLC
+// Licensed under the Academic Free License version 3.0
+//
+// History:
+//   3 May 2026  Trevor Adelman  Creation
+//
+
+using xeto
+using haystack
+using axon
+using hx
+
+**
+** RepoFuncsTest
+**
+class RepoFuncsTest : HxTest
+{
+
+  @HxTestProj
+  Void testLibRepos()
+  {
+    addLib("hx.repo")
+
+    // list repos
+    Grid grid := eval("libRepos()")
+    verify(grid.size >= 2)
+
+    // verify xetodev (default repo)
+    xetodev := grid.find { it->name == "xetodev" } ?: throw Err()
+    verifyEq(xetodev["name"], "xetodev")
+    verifyEq(xetodev["uri"],  `https://xeto.dev/`)
+
+    // verify cc repo
+    cc := grid.find { it->name == "cc" } ?: throw Err()
+    verifyEq(cc["name"], "cc")
+    verifyEq(cc["uri"],  `https://github.com/Project-Haystack/xeto-cc`)
+  }
+
+}

--- a/src/xeto/hx.repo/funcs.xeto
+++ b/src/xeto/hx.repo/funcs.xeto
@@ -1,0 +1,22 @@
+//
+// Copyright (c) 2026, SkyFoundry LLC
+// Licensed under the Academic Free License version 3.0
+//
+// History:
+//   3 May 2026  Trevor Adelman  Creation
+//
+
++Funcs {
+
+  // List configured remote repos as a grid.  The result grid
+  // includes the following columns:
+  //   - `name`: programmatic name of the repo
+  //   - `uri`: URI endpoint for the repo
+  //   - `authToken`: env var name if auth token is configured
+  //
+  // Examples:
+  //
+  //     libRepos()
+  libRepos: Func <admin> { returns: Grid }
+
+}

--- a/src/xeto/hx.repo/funcs.xeto
+++ b/src/xeto/hx.repo/funcs.xeto
@@ -15,8 +15,9 @@
   //   - `authToken`: env var name if auth token is configured
   //
   // Examples:
-  //
-  //     libRepos()
+  //   ```axon
+  //   libRepos()
+  //   ```
   libRepos: Func <admin> { returns: Grid }
 
 }

--- a/src/xeto/hx.repo/lib.xeto
+++ b/src/xeto/hx.repo/lib.xeto
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2026, SkyFoundry LLC
+// Licensed under the Academic Free License version 3.0
+//
+// History:
+//   3 May 2026  Trevor Adelman  Creation
+//
+
+pragma: Lib <
+  doc: "Remote repository management functions"
+  version: BuildVar "hx.version"
+  depends: {
+    { lib: "sys",  versions: BuildVar "ph.depend" }
+    { lib: "axon", versions: BuildVar "hx.depend" }
+    { lib: "hx",   versions: BuildVar "hx.depend" }
+  }
+  categories: {"haxall"}
+  license: BuildVar "hx.license"
+  org: {
+   dis: BuildVar "hx.org.dis"
+   uri: BuildVar "hx.org.uri"
+  }
+  vcs: {
+    type: BuildVar "hx.vcs.type"
+    uri:  BuildVar "hx.vcs.uri"
+  }
+>

--- a/src/xeto/hx.repo/lib.xeto
+++ b/src/xeto/hx.repo/lib.xeto
@@ -7,7 +7,7 @@
 //
 
 pragma: Lib <
-  doc: "Remote repository management functions"
+  doc: "Xeto remote repo management and installation"
   version: BuildVar "hx.version"
   depends: {
     { lib: "sys",  versions: BuildVar "ph.depend" }


### PR DESCRIPTION
Adds the new `hx.repo` xetolib and `hxRepo` Fantom pod with the first axon function:

- `libRepos()` - Lists configured remote repos as a grid (name, uri, authToken)

Includes:
- `lib.xeto` with libExt declaration
- `funcs.xeto` with function spec and axon code fences
- `RepoFuncs.fan` implementation
- `RepoFuncsTest.fan` test in testHx
- `build.fan` with xeto binding
- Wired into haxall build chain