### PR TITLE
hx.repo: [feat] add libRepoAdd, libRepoRemove, libRepoPing, libRepoLogin, libRepoLogout

### DIFF
--- a/src/ext/hxRepo/fan/RepoFuncs.fan
+++ b/src/ext/hxRepo/fan/RepoFuncs.fan
@@ -17,19 +17,64 @@ using hx
 const class RepoFuncs
 {
 
-  @Api @Axon { admin = true }
+  @Api @Axon { su = true }
   static Grid libRepos()
   {
-    cx := Context.cur
-    repos := cx.rt.ns.env.remoteRepos.list
-
     gb := GridBuilder()
     gb.addCol("name").addCol("uri").addCol("authToken")
-    repos.each |r|
+    repos.list.each |r|
     {
       gb.addRow([r.name, r.uri, r.authTokenEnvName])
     }
     return gb.toGrid
+  }
+
+  @Api @Axon { su = true }
+  static Dict libRepoAdd(Str name, Uri uri)
+  {
+    r := repos.add(name, uri, Etc.dict0)
+    return Etc.dict2("name", r.name, "uri", r.uri)
+  }
+
+  @Api @Axon { su = true }
+  static Str libRepoRemove(Str name)
+  {
+    repos.remove(name)
+    return "removed"
+  }
+
+  @Api @Axon { su = true }
+  static Dict libRepoPing(Str? name := null)
+  {
+    return repo(name).ping
+  }
+
+  @Api @Axon { su = true }
+  static Str libRepoLogin(Str? name, Str token)
+  {
+    n := name ?: repos.def.name
+    return repos.saveAuthToken(n, token)
+  }
+
+  @Api @Axon { su = true }
+  static Str libRepoLogout(Str? name)
+  {
+    n := name ?: repos.def.name
+    return repos.saveAuthToken(n, null)
+  }
+
+//////////////////////////////////////////////////////////////////////////
+// Utils
+//////////////////////////////////////////////////////////////////////////
+
+  private static RemoteRepoRegistry repos(Context cx := Context.cur)
+  {
+    cx.rt.ns.env.remoteRepos
+  }
+
+  private static RemoteRepo repo(Str? name, Context cx := Context.cur)
+  {
+    name == null ? repos(cx).def : repos(cx).get(name)
   }
 
 }

--- a/src/test/testHx/fan/RepoFuncsTest.fan
+++ b/src/test/testHx/fan/RepoFuncsTest.fan
@@ -37,4 +37,48 @@ class RepoFuncsTest : HxTest
     verifyEq(cc["uri"],  `https://github.com/Project-Haystack/xeto-cc`)
   }
 
+  @HxTestProj
+  Void testLibRepoAddRemove()
+  {
+    addLib("hx.repo")
+
+    // add a new repo
+    Dict added := eval("""libRepoAdd("testrepo", `https://example.com/xeto`)""")
+    verifyEq(added["name"], "testrepo")
+    verifyEq(added["uri"],  `https://example.com/xeto`)
+
+    // verify it shows up in list
+    Grid grid := eval("libRepos()")
+    row := grid.find { it->name == "testrepo" } ?: throw Err()
+    verifyEq(row["name"], "testrepo")
+    verifyEq(row["uri"],  `https://example.com/xeto`)
+
+    // remove
+    Str removed := eval("""libRepoRemove("testrepo")""")
+    verifyEq(removed, "removed")
+
+    // verify it's gone
+    grid = eval("libRepos()")
+    verifyEq(grid.find { it->name == "testrepo" }, null)
+  }
+
+  @HxTestProj
+  Void testLibRepoLoginLogout()
+  {
+    addLib("hx.repo")
+
+    // login sets auth token
+    Str envName := eval("""libRepoLogin("xetodev", "test-token-123")""")
+    verify(envName.contains("XETO_REPO"))
+
+    // verify token shows in repo list
+    Grid grid := eval("libRepos()")
+    xetodev := grid.find { it->name == "xetodev" } ?: throw Err()
+    verifyNotNull(xetodev["authToken"])
+
+    // logout clears auth token
+    envName = eval("""libRepoLogout("xetodev")""")
+    verify(envName.contains("XETO_REPO"))
+  }
+
 }

--- a/src/xeto/hx.repo/funcs.xeto
+++ b/src/xeto/hx.repo/funcs.xeto
@@ -18,6 +18,52 @@
   //   ```axon
   //   libRepos()
   //   ```
-  libRepos: Func <admin> { returns: Grid }
+  libRepos: Func <su> { returns: Grid }
+
+  // Add a new remote repo configuration.  The name must be a valid
+  // tag name and the uri must be a valid URI for the repo endpoint.
+  //
+  // Examples:
+  //   ```axon
+  //   libRepoAdd("myrepo", `https://example.com/xeto`)
+  //   ```
+  libRepoAdd: Func <su> { name: Str, uri: Uri }
+
+  // Remove a remote repo configuration by name.
+  //
+  // Examples:
+  //   ```axon
+  //   libRepoRemove("myrepo")
+  //   ```
+  libRepoRemove: Func <su> { name: Str }
+
+  // Ping a remote repo and return metadata.  If repo is null
+  // then the default repo is used.
+  //
+  // Examples:
+  //   ```axon
+  //   libRepoPing(null)
+  //   libRepoPing("xetodev")
+  //   ```
+  libRepoPing: Func <su> { repo: Str?, returns: Dict }
+
+  // Save an authentication token for a remote repo.  The token
+  // is persisted to fan.props as an environment variable.  If repo
+  // is null then the default repo is used.
+  //
+  // Examples:
+  //   ```axon
+  //   libRepoLogin("xetodev", "my-secret-token")
+  //   ```
+  libRepoLogin: Func <su> { repo: Str?, token: Str }
+
+  // Remove the authentication token for a remote repo.  If repo
+  // is null then the default repo is used.
+  //
+  // Examples:
+  //   ```axon
+  //   libRepoLogout("xetodev")
+  //   ```
+  libRepoLogout: Func <su> { repo: Str? }
 
 }


### PR DESCRIPTION
Adds phase 2 repo management functions to `hx.repo`:

- `libRepoAdd(name, uri, opts)` - Add a new remote repo configuration
- `libRepoRemove(name)` - Remove a remote repo by name
- `libRepoPing(repo)` - Ping a remote repo and return metadata
- `libRepoLogin(repo, token)` - Save auth token for a remote repo
- `libRepoLogout(repo)` - Remove auth token for a remote repo

Also updates all functions (including `libRepos`) from `admin` to `su` access level.