### PR TITLE
hxRepo: [feat] add phase 3 axon functions - libSearch, libVersions, libInstall, libUpdate, libUninstall, libFetch

### DIFF
--- a/src/ext/hxRepo/fan/RepoFuncs.fan
+++ b/src/ext/hxRepo/fan/RepoFuncs.fan
@@ -7,6 +7,7 @@
 //
 
 using xeto
+using xetom
 using haystack
 using axon
 using hx
@@ -16,6 +17,10 @@ using hx
 **
 const class RepoFuncs
 {
+
+//////////////////////////////////////////////////////////////////////////
+// Repo Management
+//////////////////////////////////////////////////////////////////////////
 
   @Api @Axon { su = true }
   static Grid libRepos()
@@ -64,6 +69,97 @@ const class RepoFuncs
   }
 
 //////////////////////////////////////////////////////////////////////////
+// Search and Versions
+//////////////////////////////////////////////////////////////////////////
+
+  @Api @Axon { su = true }
+  static Grid libSearch(Str? name, Str query)
+  {
+    r := repo(name)
+    res := r.search(RemoteRepoSearchReq(query))
+    gb := GridBuilder()
+    gb.addCol("name").addCol("version").addCol("doc")
+    res.libs.each |lib|
+    {
+      gb.addRow([lib.name, lib.version, lib.doc])
+    }
+    return gb.toGrid
+  }
+
+  @Api @Axon { su = true }
+  static Grid libVersions(Str? name, Str lib, Dict? opts := null)
+  {
+    r := repo(name)
+    vers := r.versions(lib, opts)
+    gb := GridBuilder()
+    gb.addCol("name").addCol("version").addCol("depends")
+    vers.each |v|
+    {
+      deps := v.depends(false)
+      gb.addRow([v.name, v.version, deps?.join(", ")])
+    }
+    return gb.toGrid
+  }
+
+//////////////////////////////////////////////////////////////////////////
+// Install, Update, Uninstall, Fetch
+//////////////////////////////////////////////////////////////////////////
+
+  @Api @Axon { su = true }
+  static Grid libInstall(Str? name, Obj libs, Dict? opts := null)
+  {
+    e := env
+    r := repo(name)
+    depends := toLibDepends(libs)
+    inst := LibInstaller(e, opts ?: Etc.dict0).install(r, depends)
+    if (opts?.has("preview") == true) return planToGrid(inst.plan)
+    inst.execute
+    return planToGrid(inst.plan)
+  }
+
+  @Api @Axon { su = true }
+  static Grid libUpdate(Obj libs, Dict? opts := null)
+  {
+    e := env
+    depends := toLibDepends(libs)
+    inst := LibInstaller(e, opts ?: Etc.dict0).update(depends)
+    if (opts?.has("preview") == true) return planToGrid(inst.plan)
+    inst.execute
+    return planToGrid(inst.plan)
+  }
+
+  @Api @Axon { su = true }
+  static Grid libUninstall(Obj libs)
+  {
+    cx := Context.cur
+    names := toStrList(libs)
+
+    // check if any libs are enabled in any project
+    cx.sys.proj.list.each |p|
+    {
+      names.each |n|
+      {
+        if (p.libs.has(n))
+          throw Err("Cannot uninstall '$n': lib is enabled in project '$p.name'")
+      }
+    }
+
+    e := env
+    inst := LibInstaller(e).uninstall(names)
+    inst.execute
+    return planToGrid(inst.plan)
+  }
+
+  @Api @Axon { su = true }
+  static Dict libFetch(Str? name, Str lib, Str version, Obj handle)
+  {
+    r := repo(name)
+    contents := r.fetch(lib, Version(version))
+    Context.cur.rt.exts.io.write(handle) |out| { out.writeBuf(contents) }
+    return Etc.dict4("lib", lib, "version", version, "size", Number.makeInt(contents.size), "uri", handle)
+  }
+
+//////////////////////////////////////////////////////////////////////////
 // Utils
 //////////////////////////////////////////////////////////////////////////
 
@@ -75,6 +171,39 @@ const class RepoFuncs
   private static RemoteRepo repo(Str? name, Context cx := Context.cur)
   {
     name == null ? repos(cx).def : repos(cx).get(name)
+  }
+
+  private static XetoEnv env(Context cx := Context.cur)
+  {
+    cx.rt.ns.env
+  }
+
+  private static LibDepend[] toLibDepends(Obj names)
+  {
+    return toStrList(names).map |s->LibDepend|
+    {
+      dash := s.index("-")
+      if (dash == null) return LibDepend(s)
+      return LibDepend(s[0..<dash], LibDependVersions(s[dash+1..-1]))
+    }
+  }
+
+  private static Str[] toStrList(Obj names)
+  {
+    if (names is Str) return [names]
+    if (names is List) return ((List)names).map |v->Str| { v.toStr }
+    throw ArgErr("Expected Str or List, not $names.typeof")
+  }
+
+  private static Grid planToGrid(LibInstallPlan[] plan)
+  {
+    gb := GridBuilder()
+    gb.addCol("action").addCol("name").addCol("curVer").addCol("newVer").addCol("repo")
+    plan.each |p|
+    {
+      gb.addRow([p.action, p.name, p.curVer?.version, p.newVer?.version, p.repo?.name])
+    }
+    return gb.toGrid
   }
 
 }

--- a/src/test/testHx/build.fan
+++ b/src/test/testHx/build.fan
@@ -40,7 +40,9 @@ class Build : BuildPod
                "hxd @{hx.depend}",
                "hxFolio @{hx.depend}",
                "hxConn @{hx.depend}",
-               "hxRepo @{hx.depend}"]
+               "hxRepo @{hx.depend}",
+               "xetoc @{hx.depend}",
+               "testXeto @{hx.depend}"]
     srcDirs = [`fan/`]
     resDirs = [`lib/`, `lib/connTest/`]
     index =   ["xeto.bindings":["hx.test", "hx.test.conn"], "ph.lib":"connTest" ]

--- a/src/test/testHx/fan/RepoFuncsTest.fan
+++ b/src/test/testHx/fan/RepoFuncsTest.fan
@@ -6,79 +6,321 @@
 //   3 May 2026  Trevor Adelman  Creation
 //
 
+using concurrent
 using xeto
+using xetom
+using xetoc
 using haystack
 using axon
+using folio
 using hx
+using hxm
+using hxd
+using hxRepo
+using testXeto
 
 **
-** RepoFuncsTest
+** RepoFuncsTest - tests Axon functions in hx.repo
 **
-class RepoFuncsTest : HxTest
+** This test verifies the Axon function layer: correct arg types,
+** published options, and documented return types/shapes.
+** Core business logic (file placement, env updates, dependency
+** resolution) is tested in testXeto::RemoteReposTest.
+**
+class RepoFuncsTest : RemoteReposTest
 {
 
-  @HxTestProj
-  Void testLibRepos()
-  {
-    addLib("hx.repo")
+//////////////////////////////////////////////////////////////////////////
+// Setup / Teardown
+//////////////////////////////////////////////////////////////////////////
 
-    // list repos
-    Grid grid := eval("libRepos()")
+  HxdSys? rt
+
+  override Void teardown()
+  {
+    Actor.locals.remove(Context.actorLocalsKey)
+    rt?.stop
+    super.teardown
+  }
+
+  ** Boot a test HxdSys using our custom temp ServerEnv, then wire context
+  Void initRt()
+  {
+    boot := HxdBoot.makeTest(tempDir + `rt/`, true)
+    boot.xetoEnv = this.env
+    rt = boot.init.start
+    Actor.locals[Context.actorLocalsKey] = rt.newContext(rt.sys.user.makeUser("test", ["userRole":"su"]))
+  }
+
+//////////////////////////////////////////////////////////////////////////
+// Repos
+//////////////////////////////////////////////////////////////////////////
+
+  Void testRepos()
+  {
+    initEnv
+    initRt
+
+    // libRepos - verify grid shape
+    Grid grid := RepoFuncs.libRepos
+    verifyGridCols(grid, ["name", "uri", "authToken"])
     verify(grid.size >= 2)
+    verify(grid.any { it->name == "xetodev" })
 
-    // verify xetodev (default repo)
-    xetodev := grid.find { it->name == "xetodev" } ?: throw Err()
-    verifyEq(xetodev["name"], "xetodev")
-    verifyEq(xetodev["uri"],  `https://xeto.dev/`)
+    // libRepoAdd - returns Dict with name, uri
+    Dict d := RepoFuncs.libRepoAdd("testrepo", `http://test-1/`)
+    verifyEq(d["name"], "testrepo")
+    verifyEq(d["uri"],  `http://test-1/`)
 
-    // verify cc repo
-    cc := grid.find { it->name == "cc" } ?: throw Err()
-    verifyEq(cc["name"], "cc")
-    verifyEq(cc["uri"],  `https://github.com/Project-Haystack/xeto-cc`)
-  }
+    // verify it shows up in libRepos
+    grid = RepoFuncs.libRepos
+    verify(grid.any { it->name == "testrepo" })
 
-  @HxTestProj
-  Void testLibRepoAddRemove()
-  {
-    addLib("hx.repo")
+    // libRepoPing - explicit name
+    Dict ping := RepoFuncs.libRepoPing("testrepo")
+    verifyEq(ping["ping"], "boom!")
 
-    // add a new repo
-    Dict added := eval("""libRepoAdd("testrepo", `https://example.com/xeto`)""")
-    verifyEq(added["name"], "testrepo")
-    verifyEq(added["uri"],  `https://example.com/xeto`)
+    // libRepoLogin - saves token, returns env var name
+    Str envName := RepoFuncs.libRepoLogin("testrepo", "my-secret")
+    verify(envName.contains("XETO_REPO"))
 
-    // verify it shows up in list
-    Grid grid := eval("libRepos()")
-    row := grid.find { it->name == "testrepo" } ?: throw Err()
-    verifyEq(row["name"], "testrepo")
-    verifyEq(row["uri"],  `https://example.com/xeto`)
+    // verify token is visible in repos grid
+    grid = RepoFuncs.libRepos
+    row := grid.find { it->name == "testrepo" }
+    verifyNotNull(row)
+    verify(row->authToken != null)
 
-    // remove
-    Str removed := eval("""libRepoRemove("testrepo")""")
-    verifyEq(removed, "removed")
+    // libRepoLogout - clears token, returns env var name
+    envName = RepoFuncs.libRepoLogout("testrepo")
+    verify(envName.contains("XETO_REPO"))
 
-    // verify it's gone
-    grid = eval("libRepos()")
+    // libRepoRemove - returns "removed"
+    Str s := RepoFuncs.libRepoRemove("testrepo")
+    verifyEq(s, "removed")
+
+    // verify gone
+    grid = RepoFuncs.libRepos
     verifyEq(grid.find { it->name == "testrepo" }, null)
+
+    // libRepoRemove - bad name throws
+    verifyErr(UnresolvedErr#) { RepoFuncs.libRepoRemove("badone") }
   }
 
-  @HxTestProj
-  Void testLibRepoLoginLogout()
+//////////////////////////////////////////////////////////////////////////
+// Search
+//////////////////////////////////////////////////////////////////////////
+
+  Void testSearch()
   {
-    addLib("hx.repo")
+    initEnv
+    reg.add("test", `http://test-1/`, Etc.dict0)
+    initRt
 
-    // login sets auth token
-    Str envName := eval("""libRepoLogin("xetodev", "test-token-123")""")
-    verify(envName.contains("XETO_REPO"))
+    // returns Grid with name, version, doc cols
+    Grid grid := RepoFuncs.libSearch("test", "alpha")
+    verifyGridCols(grid, ["name", "version", "doc"])
+    verify(grid.size > 0)
+    verify(grid.any { it->name == "alpha" })
 
-    // verify token shows in repo list
-    Grid grid := eval("libRepos()")
-    xetodev := grid.find { it->name == "xetodev" } ?: throw Err()
-    verifyNotNull(xetodev["authToken"])
-
-    // logout clears auth token
-    envName = eval("""libRepoLogout("xetodev")""")
-    verify(envName.contains("XETO_REPO"))
+    // empty results for unknown lib
+    grid = RepoFuncs.libSearch("test", "doesnotexist999")
+    verifyGridCols(grid, ["name", "version", "doc"])
+    verifyEq(grid.size, 0)
   }
 
+//////////////////////////////////////////////////////////////////////////
+// Versions
+//////////////////////////////////////////////////////////////////////////
+
+  Void testVersions()
+  {
+    initEnv
+    reg.add("test", `http://test-1/`, Etc.dict0)
+    initRt
+
+    // returns Grid with name, version, depends cols
+    Grid grid := RepoFuncs.libVersions("test", "alpha", null)
+    verifyGridCols(grid, ["name", "version", "depends"])
+    verify(grid.size > 0)
+    verify(grid.all { it->name == "alpha" })
+
+    // with opts (limit)
+    grid = RepoFuncs.libVersions("test", "alpha", Etc.dict1("limit", 2))
+    verifyGridCols(grid, ["name", "version", "depends"])
+    verifyEq(grid.size, 2)
+  }
+
+//////////////////////////////////////////////////////////////////////////
+// Fetch
+//////////////////////////////////////////////////////////////////////////
+
+  Void testFetch()
+  {
+    initEnv
+    reg.add("test", `http://test-1/`, Etc.dict0)
+    initRt
+
+    // fetches lib bytes and writes to file handle
+    rt.dir.plus(`io/`).create
+    fetchUri := `io/fetch-test.xetolib`
+    Dict fd := RepoFuncs.libFetch("test", "alpha", "2.3.0", fetchUri)
+    verifyEq(fd["lib"], "alpha")
+    verifyEq(fd["version"], "2.3.0")
+    verify(fd["size"] is Number)
+    verify((fd["size"] as Number).toInt > 0)
+    verifyEq(fd["uri"], fetchUri)
+    f := rt.dir.plus(`io/fetch-test.xetolib`)
+    verifyEq(f.exists, true)
+    verify(f.size > 0)
+  }
+
+//////////////////////////////////////////////////////////////////////////
+// Install
+//////////////////////////////////////////////////////////////////////////
+
+  Void testLibInstall()
+  {
+    initEnv
+    remote = reg.add("test", `http://test-1/`, Etc.dict0)
+    initRt
+
+    verifyLibNotInstalled("alpha")
+
+    // bad repo name throws
+    verifyErr(UnresolvedErr#) { RepoFuncs.libInstall("badrepo", "alpha", null) }
+
+    // single name string, no version constraint
+    Grid grid := RepoFuncs.libInstall("test", "alpha", null)
+    verifyInstallGrid(grid)
+    verifyLibInstalled("alpha", "2.3.0")
+
+    // uninstall to reset
+    RepoFuncs.libUninstall("alpha")
+    verifyLibNotInstalled("alpha")
+
+    // single name with version constraint ("name-version" format)
+    grid = RepoFuncs.libInstall("test", "alpha-1.x.x", null)
+    verifyInstallGrid(grid)
+    verifyLibInstalled("alpha", "1.2.0")
+
+    // uninstall list
+    RepoFuncs.libUninstall(["alpha"])
+    verifyLibNotInstalled("alpha")
+
+    // list of names
+    grid = RepoFuncs.libInstall("test", ["alpha", "delta"], null)
+    verifyInstallGrid(grid)
+    verifyLibInstalled("alpha", "2.3.0")
+    verifyLibInstalled("delta", "4.0.0")
+
+    // cleanup
+    RepoFuncs.libUninstall(["alpha", "delta"])
+    verifyLibNotInstalled("alpha")
+    verifyLibNotInstalled("delta")
+
+    // {preview} option: does NOT install, returns plan grid
+    grid = RepoFuncs.libInstall("test", "alpha", Etc.dict1("preview", Marker.val))
+    verifyInstallGrid(grid)
+    verifyLibNotInstalled("alpha")
+
+    // transitive deps (beta depends on alpha)
+    grid = RepoFuncs.libInstall("test", "beta-1.1.x", null)
+    verifyInstallGrid(grid)
+    verifyLibInstalled("alpha", "1.1.9")
+    verifyLibInstalled("beta",  "1.1.0")
+
+    // cleanup
+    RepoFuncs.libUninstall(["alpha", "beta"])
+    verifyLibNotInstalled("alpha")
+    verifyLibNotInstalled("beta")
+  }
+
+//////////////////////////////////////////////////////////////////////////
+// Update
+//////////////////////////////////////////////////////////////////////////
+
+  Void testUpdate()
+  {
+    initEnv
+    remote = reg.add("test", `http://test-1/`, Etc.dict0)
+    initRt
+
+    // install older versions first
+    RepoFuncs.libInstall("test", "beta-1.1.x", null)
+    verifyLibInstalled("alpha", "1.1.9")
+    verifyLibInstalled("beta",  "1.1.0")
+
+    // single name with version constraint
+    Grid grid := RepoFuncs.libUpdate("beta-2.x.x", null)
+    verifyInstallGrid(grid)
+    verifyLibInstalled("beta", "2.0.1")
+
+    // update alpha to latest 2.x.x
+    grid = RepoFuncs.libUpdate("alpha-2.x.x", null)
+    verifyInstallGrid(grid)
+    verifyLibInstalled("alpha", "2.3.0")
+
+    // list of names with constraints
+    grid = RepoFuncs.libUpdate(["alpha-2.x.x", "beta-2.x.x"], null)
+    verifyInstallGrid(grid)
+
+    // {preview} does NOT update
+    RepoFuncs.libUninstall(["alpha", "beta"])
+    RepoFuncs.libInstall("test", "beta-1.1.x", null)
+    verifyLibInstalled("beta", "1.1.0")
+    grid = RepoFuncs.libUpdate("beta-2.x.x", Etc.dict1("preview", Marker.val))
+    verifyInstallGrid(grid)
+    verifyLibInstalled("beta", "1.1.0") // still at old version
+
+    // cleanup
+    RepoFuncs.libUninstall(["alpha", "beta"])
+    verifyLibNotInstalled("alpha")
+    verifyLibNotInstalled("beta")
+  }
+
+//////////////////////////////////////////////////////////////////////////
+// Uninstall
+//////////////////////////////////////////////////////////////////////////
+
+  Void testUninstall()
+  {
+    initEnv
+    remote = reg.add("test", `http://test-1/`, Etc.dict0)
+    initRt
+
+    // install alpha and beta
+    RepoFuncs.libInstall("test", "beta-1.1.x", null)
+    verifyLibInstalled("alpha", "1.1.9")
+    verifyLibInstalled("beta",  "1.1.0")
+
+    // cannot uninstall alpha while beta depends on it
+    verifyErr(InstallPlanErr#) { RepoFuncs.libUninstall("alpha") }
+
+    // single name string
+    RepoFuncs.libUninstall("beta")
+    verifyLibNotInstalled("beta")
+
+    // list of names
+    RepoFuncs.libInstall("test", "beta-1.1.x", null)
+    Grid grid := RepoFuncs.libUninstall(["alpha", "beta"])
+    verifyInstallGrid(grid)
+    verifyLibNotInstalled("alpha")
+    verifyLibNotInstalled("beta")
+  }
+
+//////////////////////////////////////////////////////////////////////////
+// Verify Helpers
+//////////////////////////////////////////////////////////////////////////
+
+  ** Verify grid has the standard install/update/uninstall columns
+  Void verifyInstallGrid(Grid grid)
+  {
+    verifyGridCols(grid, ["action", "name", "curVer", "newVer", "repo"])
+  }
+
+  ** Verify grid column names match expected list
+  Void verifyGridCols(Grid grid, Str[] expected)
+  {
+    verifyEq(grid.cols.map |c->Str| { c.name }, expected)
+  }
 }

--- a/src/xeto/hx.repo/funcs.xeto
+++ b/src/xeto/hx.repo/funcs.xeto
@@ -66,4 +66,83 @@
   //   ```
   libRepoLogout: Func <su> { repo: Str? }
 
+  // Search a remote repo for libs matching the query string.
+  // If repo is null then the default repo is used.
+  //
+  // Examples:
+  //   ```axon
+  //   libSearch(null, "*")
+  //   libSearch("xetodev", "ph")
+  //   ```
+  libSearch: Func <su> { repo: Str?, query: Str, returns: Grid }
+
+  // List available versions for a lib from a remote repo.
+  // If repo is null then the default repo is used.  Options
+  // include `limit` and `versions` for version constraints.
+  //
+  // Examples:
+  //   ```axon
+  //   libVersions(null, "ph")
+  //   libVersions("xetodev", "ph", {limit: 5})
+  //   libVersions(null, "ph", {versions: "4.x.x"})
+  //   ```
+  libVersions: Func <su> { repo: Str?, lib: Str, opts: Dict?, returns: Grid }
+
+  // Install one or more libs from a remote repo to disk.  The libs
+  // argument accepts a single lib name or a list of lib names.  Use
+  // the format "lib-version" to specify version constraints, for
+  // example "ph-5.0.6" or "ph-5.x.x".  If no version constraint is
+  // specified, the latest available version is used.  If repo is null
+  // then the default repo is used.  Pass `{preview}` in opts to
+  // return the plan without executing.
+  //
+  // Examples:
+  //   ```axon
+  //   libInstall(null, "acme.widgets")
+  //   libInstall(null, "acme.widgets-1.x.x")
+  //   libInstall(null, ["acme.widgets", "acme.core"])
+  //   libInstall(null, "acme.widgets", {preview})
+  //   ```
+  libInstall: Func <su> { repo: Str?, libs: Obj, opts: Dict?, returns: Grid }
+
+  // Update one or more installed libs from their origin repo.
+  // The libs argument accepts a single lib name or a list of
+  // lib names.  Use the format "lib-version" to specify version
+  // constraints, for example "ph-5.x.x".  If no version constraint
+  // is specified, the latest available version is used.  Pass
+  // `{preview}` in opts to return the plan without executing.
+  //
+  // Examples:
+  //   ```axon
+  //   libUpdate("ph")
+  //   libUpdate("ph-5.x.x")
+  //   libUpdate(["ph", "ph.points"])
+  //   libUpdate("ph", {preview})
+  //   ```
+  libUpdate: Func <su> { libs: Obj, opts: Dict?, returns: Grid }
+
+  // Uninstall one or more libs from disk.  The libs argument
+  // accepts a single lib name or a list of lib names.  Raises
+  // an exception if any of the libs are currently enabled
+  // in the runtime.
+  //
+  // Examples:
+  //   ```axon
+  //   libUninstall("acme.widgets")
+  //   libUninstall(["acme.widgets", "acme.core"])
+  //   ```
+  libUninstall: Func <su> { libs: Obj, returns: Grid }
+
+  // Fetch a xetolib zip for a specific lib and version from a remote
+  // repo and write it to an I/O handle.  If repo is null then the
+  // default repo is used.  The handle follows the same conventions
+  // as `ioWriteStr`.  Returns a Dict with `lib`, `version`, `size`,
+  // and `uri` of the written file.
+  //
+  // Examples:
+  //   ```axon
+  //   libFetch(null, "ph", "4.0.5", `io/ph.xetolib`)
+  //   ```
+  libFetch: Func <su> { repo: Str?, lib: Str, version: Str, handle: Obj, returns: Dict }
+
 }

--- a/src/xeto/hx.repo/lib.xeto
+++ b/src/xeto/hx.repo/lib.xeto
@@ -13,6 +13,7 @@ pragma: Lib <
     { lib: "sys",  versions: BuildVar "ph.depend" }
     { lib: "axon", versions: BuildVar "hx.depend" }
     { lib: "hx",   versions: BuildVar "hx.depend" }
+    { lib: "hx.io", versions: BuildVar "hx.depend" }
   }
   categories: {"haxall"}
   license: BuildVar "hx.license"


### PR DESCRIPTION
Adds phase 3 Axon functions to hxRepo for lib installation, update, uninstall, search, versions, and fetch. Also rewrites RepoFuncsTest to use TempRemoteRepo test infrastructure for full offline test coverage.

**New functions in RepoFuncs.fan:**
- libSearch, libVersions, libFetch
- libInstall, libUpdate, libUninstall

**New xeto declarations in hx.repo/funcs.xeto:**
- Matching func specs with typed params and docs for all 6 new functions

**RepoFuncsTest.fan rewrite:**
- Extends RemoteReposTest (replaces HxTest) for offline TempRemoteRepo testing
- Tests all 12 functions including arg types (single, list, constraints), options (preview), error cases, and return grid shapes