### PR TITLE
xetom: JsonSchemaExporter emits description on slot props

### DIFF
--- a/src/core/xetom/fan/export/JsonSchemaExporter.fan
+++ b/src/core/xetom/fan/export/JsonSchemaExporter.fan
@@ -14,6 +14,8 @@ using yaml
 **
 ** JSON Schema Exporter
 **
+** This class does not write anything to output stream until end.
+**
 @Js
 class JsonSchemaExporter : Exporter
 {
@@ -22,7 +24,7 @@ class JsonSchemaExporter : Exporter
 // Constructor
 //////////////////////////////////////////////////////////////////////////
 
-  new make(MNamespace ns, OutStream out, Dict opts, Str refPath := "\$defs") : super(ns, out, opts)
+  new make(MNamespace ns, OutStream out, Dict opts := Etc.dict0, Str refPath := "\$defs") : super(ns, out, opts)
   {
     this.refPath = refPath
 
@@ -287,9 +289,25 @@ class JsonSchemaExporter : Exporter
 
   Obj:Obj prop(Spec slot)
   {
-    // primitives
+    res := propSchema(slot)
+
+    // attach the slot's own doc as description.  for $ref-shaped
+    // results we wrap in allOf because draft-07 ignores any sibling
+    // keys to $ref; for non-$ref results description is a direct
+    // sibling key.
+    doc := slot.metaOwn["doc"] as Str
+    if (doc == null) return res
+    if (res.containsKey("\$ref"))
+      return Obj:Obj["allOf": Obj[res], "description": doc]
+    res["description"] = doc
+    return res
+  }
+
+  private Obj:Obj propSchema(Spec slot)
+  {
+    // primitives -- dup the const lookup so the caller can mutate
     prim := primitives.getChecked(slot.type.qname, false)
-    if (prim != null) return prim
+    if (prim != null) return prim.dup
 
     // base obj -- "any" type
     if (slot.type.qname == "sys::Obj")

--- a/src/test/testXeto/fan/JsonSchemaTest.fan
+++ b/src/test/testXeto/fan/JsonSchemaTest.fan
@@ -79,6 +79,96 @@ class JsonSchemaTest : AbstractXetoTest
     verifyErr(ArgErr#) { ex.funcToParams(ns.spec("sys::Dict")) }
   }
 
+  Void testSlotDescriptions()
+  {
+    ns := createNamespace(["sys"])
+    sysVer := ns.lib("sys").version.toStr.replace(".", "-")
+    sysNumberRef := Obj:Obj["\$ref": "#/\$defs/sys-${sysVer}-Number"]
+
+    // a temp lib with a Func whose params carry slot-level <doc:"..."> meta,
+    // plus an object spec whose own slots carry <doc:"...">.  exercises both
+    // funcToParams and the doSpecObj slot-prop path through prop().
+    src :=
+      Str<|Divide: Func {
+             a: sys::Number <doc:"the dividend">,
+             b: sys::Number <doc:"the divisor">,
+             returns: sys::Number
+           }
+           Mix: Func {
+             label: sys::Str <doc:"display label">,
+             enabled: sys::Bool <doc:"whether the mix is enabled">,
+             count: sys::Int,
+             sample: sys::Obj? <doc:"opaque sample value">,
+             ids: List <of:sys::Ref, doc:"list of refs to mix in">,
+             returns: sys::Number
+           }
+           Person: {
+             name: sys::Str <doc:"full name">,
+             age: sys::Number <doc:"age in years">,
+             pet: sys::Number? <doc:"pet's age in years">
+           }|>
+
+    lib := ns.compileTempLib(src)
+
+    //
+    // funcToParams: every documented slot picks up "description"; refs
+    // get wrapped in allOf so description survives draft-07 sibling
+    // ignore rules; primitives carry description as a direct sibling.
+    //
+    ex := JsonSchemaExporter(ns, Buf().out, Etc.dict0)
+    actual := ex.funcToParams(lib.type("Divide"))
+    verifyEq(actual, Str:Obj[
+      "type": "object",
+      "properties": Str:Obj[
+        "a": Obj:Obj["allOf": Obj[sysNumberRef], "description": "the dividend"],
+        "b": Obj:Obj["allOf": Obj[sysNumberRef], "description": "the divisor"],
+      ],
+      "required": Obj["a", "b"],
+    ])
+    verifyAllRefsResolved(actual, ex.defs)
+
+    // mixed: primitives get direct description; ref + list each get the
+    // appropriate shape; sample (sys::Obj?) gets description on an empty
+    // schema; count has no doc and stays bare.
+    ex = JsonSchemaExporter(ns, Buf().out, Etc.dict0)
+    actual = ex.funcToParams(lib.type("Mix"))
+    verifyEq(actual, Str:Obj[
+      "type": "object",
+      "properties": Str:Obj[
+        "label":   Obj:Obj["type": "string", "description": "display label"],
+        "enabled": Obj:Obj["type": "boolean", "description": "whether the mix is enabled"],
+        "count":   Obj:Obj["type": "integer"],            // no doc
+        "sample":  Obj:Obj["description": "opaque sample value"],
+        "ids":     Obj:Obj[
+          "type": "array",
+          "items": Obj:Obj["\$ref": "#/\$defs/sys-${sysVer}-Ref"],
+          "description": "list of refs to mix in",
+        ],
+      ],
+      "required": Obj["label", "enabled", "count", "ids"],
+    ])
+    verifyAllRefsResolved(actual, ex.defs)
+
+    //
+    // doSpecObj: same prop() path as funcToParams, so slot docs surface
+    // as descriptions in the generated def.  spot-check the def for
+    // Person -- "name", "age" land as documented props; "pet" is a
+    // documented ref-shaped slot wrapped in allOf.
+    //
+    ex = JsonSchemaExporter(ns, Buf().out, Etc.dict0)
+    ex.spec(lib.type("Person"))
+    libVer := lib.version.toStr.replace(".", "-")
+    personDef := (Obj:Obj)ex.defs["${lib.name}-${libVer}-Person"]
+    personProps := (Obj:Obj)personDef["properties"]
+    verifyEq(personProps["name"],
+      Obj:Obj["type": "string", "description": "full name"])
+    verifyEq(personProps["age"],
+      Obj:Obj["allOf": Obj[sysNumberRef], "description": "age in years"])
+    verifyEq(personProps["pet"],
+      Obj:Obj["allOf": Obj[sysNumberRef], "description": "pet's age in years"])
+    verifyAllRefsResolved(personDef, ex.defs)
+  }
+
   private Void verifyAllRefsResolved(Obj? val, Str:Obj defs)
   {
     if (val is Map)


### PR DESCRIPTION
xetom: JsonSchemaExporter emits description on slot props from slot.doc, with allOf wrapping for -shaped slots