### PR TITLE
hxIO: normalize ioHttp response header names to lower-case

### DIFF
--- a/src/ext/hxIO/fan/IOFuncs.fan
+++ b/src/ext/hxIO/fan/IOFuncs.fan
@@ -1002,7 +1002,7 @@ const class IOFuncs
   **
   ** The callback receives three arguments:
   **   - `code`: Number HTTP status code
-  **   - `headers`: Dict of response headers
+  **   - `headers`: Dict of response headers with names normalized to lower-case
   **   - `body`: response body I/O handle for streaming reads
   **
   ** Examples:
@@ -1055,7 +1055,9 @@ const class IOFuncs
       c.readRes
       resIn := c.resIn(false)
       Obj resBody := resIn != null ? resIn : Buf()
-      return fn.call(cx, Obj?[Number(c.resCode), Etc.makeDict(c.resHeaders), resBody])
+      resHeaders := Str:Str[:]
+      c.resHeaders.each |v, n| { resHeaders[n.lower] = v }
+      return fn.call(cx, Obj?[Number(c.resCode), Etc.makeDict(resHeaders), resBody])
     }
     finally c.close
   }

--- a/src/ext/hxIO/test/HttpTest.fan
+++ b/src/ext/hxIO/test/HttpTest.fan
@@ -75,6 +75,11 @@ class HttpTest : HxTest
 
       // unsupported ref throws error
       verifyEvalErr("""ioHttp(`http://localhost:$port/echo`, "GET", {"X-Bad": @badRef}, null, (code, headers, body) => "ok")""", Err#)
+
+      // response header names are normalized to lower-case
+      Dict hRes := eval("""ioHttp(`http://localhost:$port/echo`, "GET", null, null, (code, headers, body) => headers)""")
+      verifyEq(hRes["x-echo-test"], "active")
+      verifyEq(hRes["X-Echo-Test"], null)
     }
     finally stopServer
   }

--- a/src/xeto/hx.io/funcs.xeto
+++ b/src/xeto/hx.io/funcs.xeto
@@ -448,7 +448,7 @@
   //
   // The callback receives three arguments:
   //   - code: Number - HTTP status code
-  //   - headers: Dict - response headers
+  //   - headers: Dict - response headers with names normalized to lower-case
   //   - body: response body I/O handle for streaming reads
   //
   // Examples:

--- a/src/xeto/hx.io/skills/know-io.md
+++ b/src/xeto/hx.io/skills/know-io.md
@@ -112,6 +112,12 @@ ioHttp(`https://api.acme.com/data`, "POST",
 A Ref header value resolves from the password store, keeping
 secrets out of code.
 
+Response `headers` names are normalized to lower-case (values are
+untouched), so lookups must use lower-case keys, e.g.
+`headers["content-type"]`. Dashes in header names still make them
+invalid tag names, so the headers Dict can't be used directly in
+a grid.
+
 # File Management and Zip
 
 ```axon


### PR DESCRIPTION
ioHttp() response headers are now normalized to lower-case keys before building the response Dict, giving a consistent case for lookups (e.g. headers["content-type"]).

- WebClient.resHeaders is already a case-insensitive map, so normalizing to lower-case cannot lose or collide data.
- Only response header names are normalized; header values and request headers are unchanged.
- Does not address the separate issue of dashes in header names being invalid tag names for grid/zinc use (out of scope, per discussion).

Updated fandoc, hx.io/funcs.xeto doc, and hx.io skill doc. Added a test in HttpTest verifying the response headers Dict uses lower-case keys.