### PR TITLE
hxSql:  modify sqlInsert to use batch execution.

### DIFF
--- a/etc/sql/config.props
+++ b/etc/sql/config.props
@@ -1,0 +1,3 @@
+test.uri=jdbc:mysql://localhost:3306/fantest
+test.username=fantest
+test.password=fantest

--- a/etc/sql/config.props
+++ b/etc/sql/config.props
@@ -1,3 +1,0 @@
-test.uri=jdbc:mysql://localhost:3306/fantest
-test.username=fantest
-test.password=fantest

--- a/src/conn/hxSql/fan/SqlFuncs.fan
+++ b/src/conn/hxSql/fan/SqlFuncs.fan
@@ -10,6 +10,7 @@
 using concurrent
 using sql::Col as SqlCol
 using sql::Row as SqlRow
+using sql::BatchExecutor
 using xeto
 using haystack
 using axon
@@ -137,9 +138,26 @@ const class SqlFuncs
       sqlStr := s1.add(s2).toStr
       stmt := db.sql(sqlStr).prepare
 
-      // now insert each input row
-      // TODO: this isn't very efficient, need to batch
-      results := Obj[,]
+      //// now insert each input row
+      //// TODO: this isn't very efficient, need to batch
+      //results := Obj[,]
+      //input.each |inputRow|
+      //{
+      //  params := Str:Obj?[:]
+      //  inputCols.each |inputCol|
+      //  {
+      //    name := inputCol.name
+      //    params[name] = toSqlVal(inputRow.trap(name, null), inputCol)
+      //  }
+
+      //  // execute with params and store result
+      //  r := stmt.execute(params)
+      //  if (r is List) r = ((List)r)[0]
+      //  results.add(fromSqlVal(r))
+      //}
+
+      //now insert each input row
+      batch := BatchExecutor(stmt)
       input.each |inputRow|
       {
         params := Str:Obj?[:]
@@ -148,16 +166,14 @@ const class SqlFuncs
           name := inputCol.name
           params[name] = toSqlVal(inputRow.trap(name, null), inputCol)
         }
-
-        // execute with params and store result
-        r := stmt.execute(params)
-        if (r is List) r = ((List)r)[0]
-        results.add(fromSqlVal(r))
+        batch.add(params)
       }
 
+      // finish batch, and map results from sql
+      results := batch.finish.map |r| { return fromSqlVal(r) }
+
       // return results
-      if (single) return fromSqlVal(results.first)
-      return results
+      return single ? results.first : results
     }
   }
 

--- a/src/conn/hxSql/fan/SqlFuncs.fan
+++ b/src/conn/hxSql/fan/SqlFuncs.fan
@@ -84,7 +84,7 @@ const class SqlFuncs
 
   ** Execute a SQL statement and if applicable return a result.
   ** If the statement produced auto-generated keys, then return
-  ** an list of the keys generated, otherwise return number of
+  ** a list of the keys generated, otherwise return number of
   ** rows modified.
   **
   ** WARNING: any admin user will have full access to update the
@@ -99,10 +99,13 @@ const class SqlFuncs
   }
 
   ** Insert a record or grid of records into the given table.
-  ** If data is a dict, thena single row is inserted.  If data
+  ** If data is a dict, then a single row is inserted.  If data
   ** is a grid or list of dicts, then each row is inserted.  The data's
   ** column names must match the table's columns.  If the data has a
   ** tag/column not found in the table then it is ignored.
+  **
+  ** Return a list of the keys generated, or a single key if a single row
+  ** is inserted.
   **
   ** WARNING: any admin user will have full access to update the
   ** database based on the user account configured by the sqlConn.
@@ -138,24 +141,6 @@ const class SqlFuncs
       sqlStr := s1.add(s2).toStr
       stmt := db.sql(sqlStr).prepare
 
-      //// now insert each input row
-      //// TODO: this isn't very efficient, need to batch
-      //results := Obj[,]
-      //input.each |inputRow|
-      //{
-      //  params := Str:Obj?[:]
-      //  inputCols.each |inputCol|
-      //  {
-      //    name := inputCol.name
-      //    params[name] = toSqlVal(inputRow.trap(name, null), inputCol)
-      //  }
-
-      //  // execute with params and store result
-      //  r := stmt.execute(params)
-      //  if (r is List) r = ((List)r)[0]
-      //  results.add(fromSqlVal(r))
-      //}
-
       //now insert each input row
       batch := BatchExecutor(stmt)
       input.each |inputRow|
@@ -169,11 +154,12 @@ const class SqlFuncs
         batch.add(params)
       }
 
-      // finish batch, and map results from sql
-      results := batch.finish.map |r| { return fromSqlVal(r) }
+      // finish batch, and map keys from sql
+      batch.finish
+      keys := batch.keys.map |r| { return fromSqlVal(r) }
 
-      // return results
-      return single ? results.first : results
+      // return keys
+      return single ? keys.first : keys
     }
   }
 

--- a/src/conn/hxSql/fan/SqlFuncs.fan
+++ b/src/conn/hxSql/fan/SqlFuncs.fan
@@ -155,8 +155,7 @@ const class SqlFuncs
       }
 
       // finish batch, and map keys from sql
-      batch.finish
-      keys := batch.keys.map |r| { return fromSqlVal(r) }
+      keys := batch.finish.keys.map |r| { return fromSqlVal(r) }
 
       // return keys
       return single ? keys.first : keys

--- a/src/conn/hxSql/test/SqlConnTest.fan
+++ b/src/conn/hxSql/test/SqlConnTest.fan
@@ -32,10 +32,6 @@ class SqlConnTest : HxTest
     // configure one
     sqlPod := Pod.find("sql")
 
-    echo("sqlTestInit: uri "      + sqlPod.config("test.uri").toUri)
-    echo("sqlTestInit: username " + sqlPod.config("test.username"))
-    echo("sqlTestInit: password " + sqlPod.config("test.password"))
-
     conn := addRec([
             "dis":      "Test SQL Conn",
             "sqlConn":  Marker.val,
@@ -43,9 +39,6 @@ class SqlConnTest : HxTest
             "username": sqlPod.config("test.username"),
             "sqlSyncHisExpr": "testSyncHis"])
     proj.db.passwords.set(conn.id.toStr, sqlPod.config("test.password"))
-
-    echo("sqlTestInit: conn " + conn.id)
-    echo("sqlTestInit: read " + eval("read(sqlConn)")) // <-- axon::EvalErr: Unknown symbol 'read' [eval:1]
 
     grid := (Grid)eval("read(sqlConn).sqlTables()")
     verifyEq(grid.cols[0].name, "name")
@@ -97,9 +90,6 @@ class SqlConnTest : HxTest
     addRec(["foo":Marker.val, "dis":"Gamma", "date":Date(2011, Month.jun, 7).toStr, "dur":n(5, "min")])
     Obj[] ids := eval("""readAll(foo).sort("date").sqlInsert($conn.id.toCode, "sqlext_test_basics")""")
     grid = eval("""read(sqlConn).sqlQuery("select * from sqlext_test_basics").sort("date")""")
-
-    echo("SqlConnTest.testBasics: $ids")
-    grid.dump
 
     verifyEq(grid.size, 3)
     verifyDictEq(grid[0], ["tid": aId,    "dis":"Alpha", "date":Date(2010, Month.apr, 20), "dur":"forever", "num":n(66)])

--- a/src/conn/hxSql/test/SqlConnTest.fan
+++ b/src/conn/hxSql/test/SqlConnTest.fan
@@ -97,6 +97,10 @@ class SqlConnTest : HxTest
     addRec(["foo":Marker.val, "dis":"Gamma", "date":Date(2011, Month.jun, 7).toStr, "dur":n(5, "min")])
     Obj[] ids := eval("""readAll(foo).sort("date").sqlInsert($conn.id.toCode, "sqlext_test_basics")""")
     grid = eval("""read(sqlConn).sqlQuery("select * from sqlext_test_basics").sort("date")""")
+
+    echo("SqlConnTest.testBasics: $ids")
+    grid.dump
+
     verifyEq(grid.size, 3)
     verifyDictEq(grid[0], ["tid": aId,    "dis":"Alpha", "date":Date(2010, Month.apr, 20), "dur":"forever", "num":n(66)])
     verifyDictEq(grid[1], ["tid": ids[0], "dis":"Beta",  "date":Date(2010, Month.jun, 7),  "dur":"1min"])

--- a/src/conn/hxSql/test/SqlConnTest.fan
+++ b/src/conn/hxSql/test/SqlConnTest.fan
@@ -31,14 +31,21 @@ class SqlConnTest : HxTest
 
     // configure one
     sqlPod := Pod.find("sql")
+
+    echo("sqlTestInit: uri "      + sqlPod.config("test.uri").toUri)
+    echo("sqlTestInit: username " + sqlPod.config("test.username"))
+    echo("sqlTestInit: password " + sqlPod.config("test.password"))
+
     conn := addRec([
             "dis":      "Test SQL Conn",
             "sqlConn":  Marker.val,
             "uri":      sqlPod.config("test.uri").toUri,
             "username": sqlPod.config("test.username"),
             "sqlSyncHisExpr": "testSyncHis"])
-
     proj.db.passwords.set(conn.id.toStr, sqlPod.config("test.password"))
+
+    echo("sqlTestInit: conn " + conn.id)
+    echo("sqlTestInit: read " + eval("read(sqlConn)")) // <-- axon::EvalErr: Unknown symbol 'read' [eval:1]
 
     grid := (Grid)eval("read(sqlConn).sqlTables()")
     verifyEq(grid.cols[0].name, "name")


### PR DESCRIPTION
The sqlInsert() function in hxSql has been modified so that it automatically uses sql::Statment.executeBatch() to do inserts, rather than doing them one at a time.  

Note that this PR is dependent on a [merged PR](https://github.com/fantom-lang/fantom/pull/96) in the Fantom repo, so developers will need to pull from there first in order to build hxSql.

This PR addresses [Issue 114](https://github.com/haxall/haxall/issues/114)
