### PR TITLE
hxIO: surface Set-Cookie headers in ioHttp callback

### DIFF
--- a/src/ext/hxIO/fan/IOFuncs.fan
+++ b/src/ext/hxIO/fan/IOFuncs.fan
@@ -916,8 +916,18 @@ const class IOFuncs
   **
   ** The callback receives three arguments:
   **   - code: Number - HTTP status code
-  **   - headers: Dict - response headers with names normalized to lower-case
+  **   - headers: Dict - response headers with names normalized to lower-case.
+  **     If the response set one or more cookies via `Set-Cookie`, they are
+  **     collapsed and reformatted as a "set-cookie" entry using valid
+  **     `Cookie` request header syntax ("name=value; name2=value2") so it
+  **     can be passed directly back into a subsequent `ioHttp` call's
+  **     `headers` under the "Cookie" key without any parsing.
   **   - body: response body I/O handle for streaming reads
+  **
+  ** External API responses often use JSON keys that aren't valid Haystack
+  ** tag names (e.g. containing spaces, dashes, or leading digits) — use the
+  ** `{safeNames}` option on [ioReadJson()] to convert them automatically
+  ** rather than risk a decode error.
   **
   ** Examples:
   **
@@ -937,7 +947,13 @@ const class IOFuncs
   **     ioHttp(`https://acme.com/api`, "POST",
   **       {"Secret-Header": @password, "Content-Type": "application/json; charset=utf-8"},
   **       body,
-  **       (code, headers, body) => {code: code, body: ioReadJson(body)})
+  **       (code, headers, body) => {code: code, body: ioReadJson(body, {safeNames})})
+  **
+  **     // Carry a session cookie from one request to the next
+  **     r1 := ioHttp(`https://acme.com/login`, "POST", null, credsBody,
+  **       (code, headers, body) => {code: code, cookie: headers["set-cookie"]})
+  **     ioHttp(`https://acme.com/data`, "GET", {"Cookie": r1->cookie}, null,
+  **       (code, headers, body) => ioReadJson(body, {safeNames}))
   @Api @Axon { admin = true }
   static Obj? ioHttp(Uri uri, Str method, Dict? headers, Obj? body, Fn fn)
   {
@@ -973,6 +989,9 @@ const class IOFuncs
       Obj resBody := resIn != null ? resIn : Buf()
       resHeaders := Str:Str[:]
       c.resHeaders.each |v, n| { resHeaders[n.lower] = v }
+      if (!c.cookies.isEmpty)
+        resHeaders["set-cookie"] = c.cookies.join("; ") |ck| { "${ck.name}=${ck.val}" }
+
       return fn.call(cx, Obj?[Number(c.resCode), Etc.makeDict(resHeaders), resBody])
     }
     finally c.close

--- a/src/ext/hxIO/test/HttpTest.fan
+++ b/src/ext/hxIO/test/HttpTest.fan
@@ -80,6 +80,16 @@ class HttpTest : HxTest
       Dict hRes := eval("""ioHttp(`http://localhost:$port/echo`, "GET", null, null, (code, headers, body) => headers)""")
       verifyEq(hRes["x-echo-test"], "active")
       verifyEq(hRes["X-Echo-Test"], null)
+
+      // multiple Set-Cookie response headers are parsed and reformatted
+      // into a single reusable "Cookie:" request header string
+      Dict cRes := eval("""ioHttp(`http://localhost:$port/echo`, "GET", null, null, (code, headers, body) => headers)""")
+      verifyEq(cRes["set-cookie"], "session=abc123; csrf=xyz789")
+
+      // round-trip: pass the reformatted cookie value back in as a request header
+      Dict rtRes := eval("""ioHttp(`http://localhost:$port/echo`, "GET", {"Cookie": "session=abc123; csrf=xyz789"}, null, (code, headers, body) => {code: code, body: ioReadStr(body)})""")
+      verifyEq(rtRes["code"], n(200))
+      verify(rtRes["body"].toStr.contains("cookie=session=abc123; csrf=xyz789"))
     }
     finally stopServer
   }
@@ -208,14 +218,18 @@ internal const class EchoMod : WebMod
     }
 
     xs := req.headers["X-Secret"]
+    ck := req.headers["Cookie"]
 
     res.headers["Content-Type"] = "text/plain"
     res.headers["X-Echo-Test"] = "active"
+    res.cookies.add(Cookie("session", "abc123"))
+    res.cookies.add(Cookie("csrf", "xyz789"))
     out := res.out
     out.print("method=$req.method\n")
     if (ct != null) out.print("content-type=$ct\n")
     if (cl != null) out.print("content-length=$cl\n")
     if (xs != null) out.print("x-secret=$xs\n")
+    if (ck != null) out.print("cookie=$ck\n")
     if (body.size > 0) out.print("body=$body\n")
     out.close
   }

--- a/src/xeto/hx.io/funcs.xeto
+++ b/src/xeto/hx.io/funcs.xeto
@@ -448,8 +448,18 @@
   //
   // The callback receives three arguments:
   //   - code: Number - HTTP status code
-  //   - headers: Dict - response headers with names normalized to lower-case
+  //   - headers: Dict - response headers with names normalized to lower-case.
+  //     If the response set one or more cookies via `Set-Cookie`, they are
+  //     collapsed and reformatted as a "set-cookie" entry using valid
+  //     `Cookie` request header syntax ("name=value; name2=value2") so it
+  //     can be passed directly back into a subsequent `ioHttp` call's
+  //     `headers` under the "Cookie" key without any parsing.
   //   - body: response body I/O handle for streaming reads
+  //
+  // External API responses often use JSON keys that aren't valid Haystack
+  // tag names (e.g. containing spaces, dashes, or leading digits) — use the
+  // `{safeNames}` option on [ioReadJson()] to convert them automatically
+  // rather than risk a decode error.
   //
   // Examples:
   //
@@ -469,7 +479,14 @@
   //     ioHttp(`https://acme.com/api`, "POST",
   //       {"Secret-Header": @password, "Content-Type": "application/json; charset=utf-8"},
   //       body,
-  //       (code, headers, body) => {code: code, body: ioReadJson(body)})
+  //       (code, headers, body) => {code: code, body: ioReadJson(body, {safeNames})})
+  //
+  //     // Carry a session cookie from one request to the next
+  //     r1: ioHttp(`https://acme.com/login`, "POST", null, credsBody,
+  //       (code, headers, body) => {code: code, cookie: headers["set-cookie"]})
+  //
+  //     ioHttp(`https://acme.com/data`, "GET", {"Cookie": r1->cookie}, null,
+  //       (code, headers, body) => ioReadJson(body, {safeNames}))
   ioHttp: Func <admin> { uri: Uri, method: Str, headers: Dict?, body: Obj?, fn: Func, returns: Obj? }
 
 }


### PR DESCRIPTION
Surfaces `WebClient.cookies` (already parsed by `web`) as `headers["set-cookie"]` in the `ioHttp` callback, so a session cookie can be copied straight into the next request's `Cookie` header:

```
r1: ioHttp(`https://acme.com/login`, "POST", null, credsBody,
  (code, headers, body) => {code: code, cookie: headers["set-cookie"]})

ioHttp(`https://acme.com/data`, "GET", {"Cookie": r1->cookie}, null,
  (code, headers, body) => ioReadJson(body, {safeNames}))
```

Also updated doc comments in `IOFuncs.fan` and `hx.io/funcs.xeto` with this example and a note on using `{safeNames}` for `ioReadJson()`.

Added test coverage in `HttpTest`. Full `hxIO` suite passes (328 verifies). Manually verified against postman-echo.com and httpbin.org.