### PR TITLE
xetom: fix OpenApiExporter codegen compat (typed enum header, operationId)

### DIFF
--- a/src/core/xetom/fan/export/OpenApiExporter.fan
+++ b/src/core/xetom/fan/export/OpenApiExporter.fan
@@ -57,8 +57,11 @@ class OpenApiExporter : Exporter
           "name": "Xeto-Version",
           "in": "header",
           "required": true,
+          // single-element enum, not const: openapi-python-client
+          // rejects const in header params even with an explicit type
           "schema": [
-            "const": sysVer.major.toStr,
+            "type": "string",
+            "enum": [sysVer.major.toStr],
           ]
         ]
       ]
@@ -207,12 +210,14 @@ class OpenApiExporter : Exporter
     // GET
     if (fileParam == null && props.isEmpty && spec.meta.has("noSideEffects"))
       path["get"] =  [
+        "operationId": spec.name,
         "responses": responses,
         "parameters": opParams,
       ]
     // POST
     else
       path["post"] =  [
+        "operationId": spec.name,
         "requestBody": requestBody,
         "responses": responses,
         "parameters": opParams,

--- a/src/test/testXeto/fan/OpenApiTest.fan
+++ b/src/test/testXeto/fan/OpenApiTest.fan
@@ -141,6 +141,41 @@ class OpenApiTest : AbstractXetoTest
   }
 
   **
+  ** Codegen compatibility: the two properties stock generators depend on
+  ** beyond spec validity.  The header param schema must be a typed enum --
+  ** generators reject const in header params and silently drop every
+  ** endpoint that references it.  And every operation must carry an
+  ** operationId or generators manufacture names from the URL path.
+  **
+  Void testCodegenCompat()
+  {
+    ns := createNamespace(["sys", "sys.api"])
+    buf := StrBuf()
+    ex := OpenApiExporter(ns, buf.out, Etc.dict1("format", "json"))
+    ex.start
+    ex.lib(ns.lib("sys.api"))
+    ex.end
+
+    doc := (Str:Obj?)JsonInStream(buf.toStr.in).readJson
+
+    // header param schema is a typed single-element enum
+    components := (Str:Obj?)doc["components"]
+    xetoVersion := (Str:Obj?)((Str:Obj?)components["parameters"])["xetoVersion"]
+    schema := (Str:Obj?)xetoVersion["schema"]
+    verifyEq(schema["type"], "string")
+    verifyEq(schema["enum"], Obj?[ns.sysLib.version.major.toStr])
+
+    // every operation carries an operationId equal to the op name
+    paths := (Str:Obj?)doc["paths"]
+    paths.each |Obj? path, Str uri|
+    {
+      op := (Str:Obj?)(((Str:Obj?)path)["get"] ?: ((Str:Obj?)path)["post"])
+      name := uri[uri.indexr(".")+1..-1]
+      verifyEq(op["operationId"], name)
+    }
+  }
+
+  **
   ** C4: a cross-lib collision of <op> names is a generator error, not a
   ** silent last-wins -- the published surface is addressed by unqualified
   ** name in Axon.


### PR DESCRIPTION
Two small fixes so the OpenAPI export works out of the box with stock code generators (follow-up to the email thread):

**1. Xeto-Version header: typed single-element enum instead of bare `const`**

openapi-python-client rejects `const` in header parameters (even with an explicit `type`) and silently drops every endpoint that references it — which is all of them. `{"type": "string", "enum": ["5"]}` expresses the same constraint and is universally parsed. Marker `const` in body schemas is untouched — generators handle those fine.

**2. Emit `operationId` on each operation**

Generators use it to name client methods; without it they mangle names from the URL path (`api_proj_name_..._create_order_post`). Op simple-names are already guaranteed unique by `checkCollision`, so `spec.name` is emitted directly.

**Verification**

- Raw export → openapi-python-client 0.29 with zero preprocessing: full endpoint layer, clean names; generated client ran a create/read/list/cancel round trip against a live hxd instance
- openapi-generator-cli 7.25 python + typescript-fetch targets both clean
- openapi-spec-validator passes; Redocly lint's `operation-operationId` warnings resolved
- Added `testCodegenCompat` covering both properties; full `fant testXeto` passes