### PR TITLE
xetom: OpenAPI export fidelity to the v5 dispatcher wire

### DIFF
--- a/src/core/xetom/fan/export/JsonSchemaExporter.fan
+++ b/src/core/xetom/fan/export/JsonSchemaExporter.fan
@@ -109,7 +109,12 @@ class JsonSchemaExporter : Exporter
     funcSpec.slots.each |slot, name|
     {
       if (name == "returns") return
-      if (!slot.isMaybe) required.add(name)
+      // required means the key must be present, and the dispatcher does not
+      // require presence for a defaulted param: mapArgs falls back to the
+      // metaOwn default when the arg is omitted.  metaOwn, not meta, so an
+      // example val inherited from the param's type is never mistaken for
+      // a default -- the same distinction mapArgs draws.
+      if (!slot.isMaybe && slot.metaOwn.missing("val")) required.add(name)
       props[name] = prop(slot)
     }
 

--- a/src/core/xetom/fan/export/JsonSchemaExporter.fan
+++ b/src/core/xetom/fan/export/JsonSchemaExporter.fan
@@ -109,11 +109,7 @@ class JsonSchemaExporter : Exporter
     funcSpec.slots.each |slot, name|
     {
       if (name == "returns") return
-      // required means the key must be present, and the dispatcher does not
-      // require presence for a defaulted param: mapArgs falls back to the
-      // metaOwn default when the arg is omitted.  metaOwn, not meta, so an
-      // example val inherited from the param's type is never mistaken for
-      // a default -- the same distinction mapArgs draws.
+      // omit defaulted params from required to match hxApi::ApiDispatch.mapArgs
       if (!slot.isMaybe && slot.metaOwn.missing("val")) required.add(name)
       props[name] = prop(slot)
     }

--- a/src/core/xetom/fan/export/OpenApiExporter.fan
+++ b/src/core/xetom/fan/export/OpenApiExporter.fan
@@ -142,11 +142,13 @@ class OpenApiExporter : Exporter
     if (!isOp(spec)) return
     checkCollision(spec)
 
+    // the wire path is the qname form the dispatcher resolves --
+    // "lib::func", never the dotted form
     uri := spec.qname
     n := uri.index("::Funcs.")
     if (n != null)
       uri = uri[0..n+1] + uri[(n+"..Funcs.".size)..-1]
-    uri = "/api/{projName}/" + uri.replace("::", ".")
+    uri = "/api/{projName}/" + uri
 
     // request body: a file typed param receives the raw body per the
     // dispatcher's upload contract, everything else is the JSON args object
@@ -175,7 +177,12 @@ class OpenApiExporter : Exporter
     returns := spec.slot("returns", false)
     if (returns != null)
     {
-      response = schemaExporter.prop(returns)
+      // a None return answers literal JSON null on the jeto wire, not the
+      // "∅" sentinel None uses in slot positions
+      if (returns.type.qname == "sys::None")
+        response = Obj:Obj["type": "null"]
+      else
+        response = schemaExporter.prop(returns)
       // the response body has no key to omit, so a maybe return really can
       // answer JSON null -- ApiDispatchV5 writes it literally
       if (returns.isMaybe)

--- a/src/core/xetom/fan/export/OpenApiExporter.fan
+++ b/src/core/xetom/fan/export/OpenApiExporter.fan
@@ -142,13 +142,7 @@ class OpenApiExporter : Exporter
     if (!isOp(spec)) return
     checkCollision(spec)
 
-    // the wire path is the qname form the dispatcher resolves --
-    // "lib::func", never the dotted form
-    uri := spec.qname
-    n := uri.index("::Funcs.")
-    if (n != null)
-      uri = uri[0..n+1] + uri[(n+"..Funcs.".size)..-1]
-    uri = "/api/{projName}/" + uri
+    uri := "/api/{projName}/" + spec.func.qname
 
     // request body: a file typed param receives the raw body per the
     // dispatcher's upload contract, everything else is the JSON args object
@@ -177,9 +171,8 @@ class OpenApiExporter : Exporter
     returns := spec.slot("returns", false)
     if (returns != null)
     {
-      // a None return answers literal JSON null on the jeto wire, not the
-      // "∅" sentinel None uses in slot positions
-      if (returns.type.qname == "sys::None")
+      // Jeto encodes a None return as JSON null, not the "∅" slot sentinel
+      if (returns.type.isNone)
         response = Obj:Obj["type": "null"]
       else
         response = schemaExporter.prop(returns)

--- a/src/test/testXeto/fan/JsonSchemaTest.fan
+++ b/src/test/testXeto/fan/JsonSchemaTest.fan
@@ -60,7 +60,8 @@ class JsonSchemaTest : AbstractXetoTest
     ])
     verifyAllRefsResolved(actual, ex.defs)
 
-    // readByIds: Func { ids: List <of:Ref>, checked: Bool, returns: Grid }
+    // readByIds: Func { ids: List <of:Ref>, checked: Bool "true", returns: Grid }
+    // checked has a metaOwn default so it may be omitted -- not required
     ex = JsonSchemaExporter(ns, Buf().out, Etc.dict0)
     actual = ex.funcToParams(apiFuncs.slot("readByIds"))
     verifyEq(actual, Str:Obj[
@@ -69,7 +70,7 @@ class JsonSchemaTest : AbstractXetoTest
         "ids": Obj:Obj["type": "array", "items": sysRefRef],
         "checked": Obj:Obj["type": "boolean"],
       ],
-      "required": Obj["ids", "checked"],
+      "required": Obj["ids"],
     ])
     verifyAllRefsResolved(actual, ex.defs)
 

--- a/src/test/testXeto/fan/JsonSchemaTest.fan
+++ b/src/test/testXeto/fan/JsonSchemaTest.fan
@@ -61,7 +61,7 @@ class JsonSchemaTest : AbstractXetoTest
     verifyAllRefsResolved(actual, ex.defs)
 
     // readByIds: Func { ids: List <of:Ref>, checked: Bool "true", returns: Grid }
-    // checked has a metaOwn default so it may be omitted -- not required
+    // checked has a metaOwn default so it may be omitted, not required
     ex = JsonSchemaExporter(ns, Buf().out, Etc.dict0)
     actual = ex.funcToParams(apiFuncs.slot("readByIds"))
     verifyEq(actual, Str:Obj[

--- a/src/test/testXeto/fan/OpenApiTest.fan
+++ b/src/test/testXeto/fan/OpenApiTest.fan
@@ -30,13 +30,13 @@ class OpenApiTest : AbstractXetoTest
     ex.lib(ns.lib("axon"))
 
     // sys.api marks its funcs <op>
-    verify(ex.paths.containsKey("/api/{projName}/sys.api.readById"))
-    verify(ex.paths.containsKey("/api/{projName}/sys.api.about"))
+    verify(ex.paths.containsKey("/api/{projName}/sys.api::readById"))
+    verify(ex.paths.containsKey("/api/{projName}/sys.api::about"))
 
     // axon is vocabulary, not an API surface -- nothing from it publishes
     ex.paths.keys.each |k|
     {
-      verify(((Str)k).startsWith("/api/{projName}/sys.api."), "unexpected path: $k")
+      verify(((Str)k).startsWith("/api/{projName}/sys.api::"), "unexpected path: $k")
     }
   }
 
@@ -50,12 +50,12 @@ class OpenApiTest : AbstractXetoTest
     ex.lib(ns.lib("sys.api"))
 
     // about: Func <op, noSideEffects> { returns: AboutInfo } -- no params
-    about := (Obj:Obj)ex.paths.getChecked("/api/{projName}/sys.api.about")
+    about := (Obj:Obj)ex.paths.getChecked("/api/{projName}/sys.api::about")
     verifyNotNull(about["get"])
     verifyEq(about["post"], null)
 
     // close: Func <op> { returns: None } -- side effects, so POST
-    close := (Obj:Obj)ex.paths.getChecked("/api/{projName}/sys.api.close")
+    close := (Obj:Obj)ex.paths.getChecked("/api/{projName}/sys.api::close")
     verifyNotNull(close["post"])
     verifyEq(close["get"], null)
 
@@ -76,7 +76,7 @@ class OpenApiTest : AbstractXetoTest
     ex := OpenApiExporter(ns, Buf().out, Etc.dict0)
     ex.lib(ns.lib("sys.api"))
 
-    about := (Obj:Obj)ex.paths.getChecked("/api/{projName}/sys.api.about")
+    about := (Obj:Obj)ex.paths.getChecked("/api/{projName}/sys.api::about")
     responses := (Obj:Obj)((Obj:Obj)about["get"])["responses"]
 
     verifyNotNull(responses["200"])
@@ -121,13 +121,13 @@ class OpenApiTest : AbstractXetoTest
     ex.lib(ns.lib("sys.repo"))
 
     // repoPublish { file: XetoLibFile } uploads the raw body
-    pub := (Obj:Obj)ex.paths.getChecked("/api/{projName}/sys.repo.repoPublish")
+    pub := (Obj:Obj)ex.paths.getChecked("/api/{projName}/sys.repo::repoPublish")
     body := (Obj:Obj)((Obj:Obj)pub["post"])["requestBody"]
     schema := binarySchema((Obj:Obj)body["content"])
     verifyEq(schema["format"], "binary")
 
     // repoFetch returns XetoLibFile as a raw download
-    fetch := (Obj:Obj)ex.paths.getChecked("/api/{projName}/sys.repo.repoFetch")
+    fetch := (Obj:Obj)ex.paths.getChecked("/api/{projName}/sys.repo::repoFetch")
     responses := (Obj:Obj)((Obj:Obj)fetch["post"])["responses"]
     ok := (Obj:Obj)responses.getChecked("200")
     schema = binarySchema((Obj:Obj)ok["content"])
@@ -170,9 +170,40 @@ class OpenApiTest : AbstractXetoTest
     paths.each |Obj? path, Str uri|
     {
       op := (Str:Obj?)(((Str:Obj?)path)["get"] ?: ((Str:Obj?)path)["post"])
-      name := uri[uri.indexr(".")+1..-1]
+      name := uri[uri.indexr(":")+1..-1]
       verifyEq(op["operationId"], name)
     }
+  }
+
+  **
+  ** Doc fidelity to the dispatcher's wire behavior.  A None return answers
+  ** literal JSON null on the jeto wire, so the doc must say "null" rather
+  ** than the "∅" sentinel None uses in slot positions.  And a non-maybe
+  ** param with a metaOwn default may be omitted -- mapArgs falls back to
+  ** the default -- so it must not land in "required".
+  **
+  Void testWireFidelity()
+  {
+    ns := createNamespace(["sys", "sys.api"])
+    ex := OpenApiExporter(ns, Buf().out, Etc.dict0)
+    ex.lib(ns.lib("sys.api"))
+
+    // close: Func <op> { returns: None } documents a null response body
+    close := (Obj:Obj)ex.paths.getChecked("/api/{projName}/sys.api::close")
+    responses := (Obj:Obj)((Obj:Obj)close["post"])["responses"]
+    ok := (Obj:Obj)responses.getChecked("200")
+    content := (Obj:Obj)((Obj:Obj)ok["content"])["application/json"]
+    verifyEq(((Obj:Obj)content["schema"])["type"], "null")
+
+    // readByIds { ids: List<of:Ref>, checked: Bool "true" }: the defaulted
+    // checked param is omittable, the undefaulted ids is required
+    read := (Obj:Obj)ex.paths.getChecked("/api/{projName}/sys.api::readByIds")
+    body := (Obj:Obj)((Obj:Obj)read["post"])["requestBody"]
+    reqContent := (Obj:Obj)((Obj:Obj)body["content"])["application/json"]
+    schema := (Obj:Obj)reqContent["schema"]
+    required := (Obj[])schema.getChecked("required")
+    verify(required.contains("ids"))
+    verify(!required.contains("checked"))
   }
 
   **

--- a/src/test/testXeto/fan/OpenApiTest.fan
+++ b/src/test/testXeto/fan/OpenApiTest.fan
@@ -176,11 +176,8 @@ class OpenApiTest : AbstractXetoTest
   }
 
   **
-  ** Doc fidelity to the dispatcher's wire behavior.  A None return answers
-  ** literal JSON null on the jeto wire, so the doc must say "null" rather
-  ** than the "∅" sentinel None uses in slot positions.  And a non-maybe
-  ** param with a metaOwn default may be omitted -- mapArgs falls back to
-  ** the default -- so it must not land in "required".
+  ** Doc fidelity to the dispatcher wire: a None return documents as JSON
+  ** null, and a param with a metaOwn default is omitted from required.
   **
   Void testWireFidelity()
   {


### PR DESCRIPTION
Three places the exported doc disagreed with the v5 dispatcher:

1. **qname op paths**: removed `.replace("::", ".")` so paths emit `/api/{projName}/sys.api::about`, the form the dispatcher resolves. operationId stays the simple name.
2. **`returns: None`** now documents `{"type": "null"}` -- the literal JSON null the dispatcher answers. None keeps its `"∅"` sentinel in slot positions.
3. **Defaulted params** are omitted from `required`, mirroring the metaOwn distinction `mapArgs` draws.

Tests updated plus new `testWireFidelity`. Verified end-to-end: export -> openapi-python-client -> live v5 calls with zero doc preprocessing.