### PR TITLE
Add complete Xeto RDF and SHACL export support

### DIFF
--- a/src/core/xetom/fan/export/JsonExporter.fan
+++ b/src/core/xetom/fan/export/JsonExporter.fan
@@ -22,6 +22,10 @@ class JsonExporter : Exporter
 
   new make(MNamespace ns, OutStream out, Dict opts) : super(ns, out, opts)
   {
+    box := opts["box"] ?: "none"
+    if (box != "none" && box != "auto" && box != "all")
+      throw ArgErr("Invalid JSON scalar boxing mode: ${box}")
+    this.instanceScalarOpts = Etc.dict1("box", box)
   }
 
 //////////////////////////////////////////////////////////////////////////
@@ -59,14 +63,19 @@ class JsonExporter : Exporter
     relId := XetoUtil.qnameToName(instance.id.id)
     prop(relId).obj
 
+    instanceValues = true
+
     spec := instance["spec"]
-    if (spec != null) dictPair("spec", spec)
+    if (spec != null) dictPairPlain("spec", spec)
 
     instance.each |v, n|
     {
       if (n == "spec") return
-      dictPair(n, v)
+      if (n == "id") dictPairPlain(n, v)
+      else dictPair(n, v)
     }
+
+    instanceValues = false
 
     objEnd.propEnd
     return this
@@ -168,7 +177,18 @@ class JsonExporter : Exporter
 
   private This dictPair(Str n, Obj v)
   {
-    prop(n).val(v).propEnd
+    if (instanceValues && (n == "id" || n == "spec"))
+      return dictPairPlain(n, v)
+    return prop(n).val(v).propEnd
+  }
+
+  ** Structural identity fields stay plain even when instance values use
+  ** lossless scalar boxes, so consumers can locate and type each record.
+  private This dictPairPlain(Str n, Obj v)
+  {
+    prop(n)
+    JetoWriter(ns, out, null, boxNone).writeVal(v)
+    return propEnd
   }
 
   private This list(Obj[] x)
@@ -182,13 +202,11 @@ class JsonExporter : Exporter
     return this
   }
 
-  ** Boxing is pinned off: the schema types every scalar as a string with a
-  ** pattern, so a boxed scalar - an object - would not validate against the
-  ** schema this exporter itself generates.  Do not let this inherit the
-  ** codec default, which is auto.
+  ** Schema data retains the established unboxed JSON format. An explicit
+  ** instance transport mode may box runtime scalars so their types survive.
   private This scalar(Obj x)
   {
-    JetoWriter(ns, out, null, boxNone).writeVal(x)
+    JetoWriter(ns, out, null, instanceValues ? instanceScalarOpts : boxNone).writeVal(x)
     return this
   }
 
@@ -279,4 +297,6 @@ class JsonExporter : Exporter
 
   private Bool[] firsts := Bool[true]    // object state stack
   private Bool lastWasEnd
+  private Bool instanceValues
+  private const Dict instanceScalarOpts
 }

--- a/src/core/xetom/fan/export/JsonExporter.fan
+++ b/src/core/xetom/fan/export/JsonExporter.fan
@@ -96,6 +96,7 @@ class JsonExporter : Exporter
     effective := this.isEffective && depth <= 1
     meta(effective  ? spec.meta  : spec.metaOwn)
     slots(effective ? spec.slots : spec.slotsOwn, depth)
+    globals(spec.globalsOwn, depth)
     objEnd.propEnd
     return this
   }
@@ -104,6 +105,12 @@ class JsonExporter : Exporter
   private This specType(Spec spec)
   {
     prop("type").str(spec.type.qname).propEnd
+    // Preserve the declaration identity of a concrete slot that specializes
+    // a global. Effective metadata alone carries the narrowed constraints but
+    // cannot reconstruct the normative RDF subproperty relationship.
+    if (spec.base != null && !spec.base.isType)
+      prop("base").str(spec.base.qname).propEnd
+    return this
   }
 
   ** Spec base
@@ -119,6 +126,17 @@ class JsonExporter : Exporter
     if (slots.isEmpty) return this
     prop("slots").obj
     slots.each |slot| { doSpec(slot.name, slot, depth+1) }
+    objEnd.propEnd
+    return this
+  }
+
+  ** Global declarations are not ordinary effective slots, but downstream
+  ** schema translators need their identity to preserve global contracts.
+  private This globals(SpecMap globals, Int depth)
+  {
+    if (globals.isEmpty) return this
+    prop("globals").obj
+    globals.each |globalSlot| { doSpec(globalSlot.name, globalSlot, depth+1) }
     objEnd.propEnd
     return this
   }
@@ -262,4 +280,3 @@ class JsonExporter : Exporter
   private Bool[] firsts := Bool[true]    // object state stack
   private Bool lastWasEnd
 }
-

--- a/src/core/xetom/fan/export/RdfExporter.fan
+++ b/src/core/xetom/fan/export/RdfExporter.fan
@@ -13,7 +13,6 @@ using haystack
 ** RDF Turtle Exporter
 **
 ** TODO
-**   - list slots not supported
 **   - query constraints not implemented
 **
 @Js
@@ -159,10 +158,8 @@ class RdfExporter : Exporter
     w("  a sys:Class ;").nl
     w("  a rdfs:Class ;").nl
 
-    // Choice members are instances of themselves. Other classes are SHACL
-    // shapes only when they have effective constraints to validate.
-    if (isThisInstance(x)) w("  a ").qname(x.qname).w(" ;").nl
-    else if (hasShape) w("  a sh:NodeShape ;").nl
+    // Classes with effective constraints are also SHACL node shapes.
+    if (hasShape) w("  a sh:NodeShape ;").nl
 
     // supertype
     if (x.base != null) w("  rdfs:subClassOf ").qname(x.base.qname).w(" ;").nl
@@ -198,17 +195,6 @@ class RdfExporter : Exporter
     }
 
     return this
-  }
-
-  private Bool isThisInstance(Spec x)
-  {
-    if (x.isChoice)
-    {
-      // Choice and first level of Choice inheritance are not
-      if (x.base.lib.name == "sys") return false
-      return true
-    }
-    return false
   }
 
   private Void hasMarker(Spec slot)
@@ -257,7 +243,14 @@ class RdfExporter : Exporter
     }
     else if (type.isChoice)
     {
-      throw UnsupportedErr("RDF mapping not implemented for choice slot ${slot.qname}")
+      choice := ns.choice(slot)
+      hasMinCount = !choice.isMaybe
+      hasMaxCount = !choice.isMultiChoice
+    }
+    else if (type.isList)
+    {
+      // List item and size constraints are emitted below on the RDF
+      // collection path. The outer slot remains one list value.
     }
     else if (type.isDict)
     {
@@ -281,8 +274,92 @@ class RdfExporter : Exporter
     w("    sh:path ").qname(slot.qname).w(" ;").nl
     sh.each |v, n| { w("    sh:").w(n).w(" ").w(v).w(" ;").nl }
     if (type.isEnum) enumConstraint(type)
+    if (type.isChoice) choiceConstraint(slot)
+    if (type.isList) listConstraint(slot)
     if (datatype != null) scalarConstraints(slot, datatype)
     w("  ] ;").nl
+  }
+
+  private Void choiceConstraint(Spec slot)
+  {
+    // The RDF specification constrains a choice slot to the member IRIs
+    // visible in the active namespace, rather than to marker values.
+    members := choiceMembers(slot)
+    w("    sh:in (")
+    members.each |member, i|
+    {
+      if (i > 0) w(" ")
+      qname(member.qname)
+    }
+    w(") ;").nl
+  }
+
+  private Spec[] choiceMembers(Spec slot)
+  {
+    choice := ns.choice(slot)
+
+    // Namespace types cover installed dependency libraries. curLib is merged
+    // explicitly because temporary or currently-exported libraries are not
+    // necessarily installed in Namespace.eachType yet. Key by qname so a
+    // library visible through both paths contributes each candidate once.
+    candidates := Str:Spec[:]
+    ns.eachType |candidate| { candidates[candidate.qname] = candidate }
+    curLib?.types?.each |candidate| { candidates[candidate.qname] = candidate }
+
+    members := Spec[,]
+    candidates.each |candidate|
+    {
+      if (!candidate.isChoice) return
+      if (!candidate.isa(choice.type)) return
+      if (!candidate.slots.list.any |Spec memberSlot->Bool| { memberSlot.isMarker }) return
+      members.add(candidate)
+    }
+    members.sort |a, b| { a.qname <=> b.qname }
+    return members
+  }
+
+  private Void listConstraint(Spec slot)
+  {
+    of := slot.of(false)
+    validateListItemType(slot, of)
+
+    minSize := intMeta(slot.meta["minSize"])
+    if (slot.meta.has("nonEmpty") && (minSize == null || minSize < 1)) minSize = 1
+    maxSize := intMeta(slot.meta["maxSize"])
+    if (of == null && minSize == null && maxSize == null) return
+
+    // A Xeto list is one slot value represented by an RDF collection. The
+    // outer property shape handles list presence/cardinality; this nested
+    // shape applies item type and size constraints along rdf:rest*/rdf:first.
+    w("    sh:node [").nl
+    w("      sh:property [").nl
+    w("        sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;").nl
+    if (of != null)
+    {
+      if (of.isScalar)
+        w("        sh:datatype ").w(scalarDatatype(of)).w(" ;").nl
+      else if (of.isDict)
+        w("        sh:class ").qname(of.qname).w(" ;").nl
+    }
+    if (minSize != null) w("        sh:minCount ").w(minSize).w(" ;").nl
+    if (maxSize != null) w("        sh:maxCount ").w(maxSize).w(" ;").nl
+    w("      ]").nl
+    w("    ] ;").nl
+  }
+
+  private Void validateListItemType(Spec slot, Spec? of)
+  {
+    if (of == null) return
+
+    // The current public mapping defines scalar and direct-dictionary items.
+    // Deferred forms fail closed instead of being omitted or stringified.
+    kind := "item type ${of.qname}"
+    if (of.isEnum) kind = "enum item type ${of.qname}"
+    else if (of.isChoice) kind = "choice item type ${of.qname}"
+    else if (of.isRef || of.isMultiRef) kind = "reference item type ${of.qname}"
+    else if (of.isList) kind = "nested-list item type ${of.qname}"
+    else if (of.isScalar || of.isDict) return
+    throw UnsupportedErr("RDF list mapping not supported for ${slot.qname}: ${kind}")
   }
 
   private Void enumConstraint(Spec type)
@@ -483,11 +560,25 @@ class RdfExporter : Exporter
 
   private Void instanceMembers(Dict instance, Spec spec, Str indent)
   {
+    choiceMarkers := Str:Bool[:]
+    spec.slots.each |slot|
+    {
+      if (!slot.isChoice) return
+      instanceChoiceSelections(instance, slot).each |selection|
+      {
+        selection.slots.each |marker|
+        {
+          if (marker.isMarker) choiceMarkers[marker.name] = true
+        }
+      }
+    }
+
     members := ns.reflect(instance, spec).members.dup
     members.sort |a, b| { instanceProperty(spec, a) <=> instanceProperty(spec, b) }
     members.each |member|
     {
       if (member.name == "id" || member.name == "spec" || member.isChoice) return
+      if (choiceMarkers.containsKey(member.name)) return
 
       val := member.val
       slot := member.spec
@@ -495,7 +586,9 @@ class RdfExporter : Exporter
       if (val == null) return
 
       property := instanceProperty(spec, member)
-      type := slot.isSlot ? slot.type : slot
+      // Parameterized list metadata such as `of` and size constraints lives
+      // on the slot spec, not the shared sys::List type.
+      type := slot.isSlot && slot.type.isList ? slot : (slot.isSlot ? slot.type : slot)
       instanceMember(property, type, val, indent)
     }
   }
@@ -535,6 +628,12 @@ class RdfExporter : Exporter
       if (type.enum.spec(key, false) == null)
         throw UnsupportedErr("Invalid ${type.qname} value: ${key}")
       w(indent).qname(property).w(" ").literal(key).w("^^xsd:string ;").nl
+      return
+    }
+
+    if (type.isList)
+    {
+      instanceList(property, type, val, indent)
       return
     }
 
@@ -610,13 +709,78 @@ class RdfExporter : Exporter
     w(indent).w("] ;").nl
   }
 
+  private Void instanceList(Str property, Spec listType, Obj val, Str indent)
+  {
+    items := val as List ?: throw UnsupportedErr("Expected List for ${property}, not ${val.typeof}")
+    of := listType.of(false)
+    validateListItemType(listType, of)
+
+    w(indent).qname(property).w(" (")
+    if (!items.isEmpty) nl
+    items.each |item|
+    {
+      w(indent).w("  ")
+      instanceListItem(property, of, item, indent + "  ")
+      nl
+    }
+    if (!items.isEmpty) w(indent)
+    w(") ;").nl
+  }
+
+  private Void instanceListItem(Str property, Spec? declaredType, Obj item, Str indent)
+  {
+    type := declaredType ?: ns.specOf(item, false)
+    if (type == null)
+      throw UnsupportedErr("RDF list item type not known for ${property}: ${item.typeof}")
+    validateListItemType(type, type)
+
+    if (type.isScalar)
+    {
+      num := item as Number
+      if (num != null && num.unit != null)
+        throw UnsupportedErr("RDF quantity list item mapping not implemented for ${property}")
+      typedLiteral(item, scalarDatatype(type))
+      return
+    }
+
+    if (type.isDict)
+    {
+      nested := item as Dict ?: throw UnsupportedErr("Expected Dict item for ${property}, not ${item.typeof}")
+      nestedId := nested["id"] as Ref
+      if (nestedId != null)
+      {
+        id(nestedId)
+        return
+      }
+
+      nestedSpec := instanceSpec(nested)
+      w("[").nl
+      w(indent).w("  a ").qname(nestedSpec.qname).w(" ;").nl
+      instanceMembers(nested, nestedSpec, indent + "  ")
+      w(indent).w("]")
+      return
+    }
+
+    throw UnsupportedErr("RDF list item mapping not supported for ${property}: ${type.qname}")
+  }
+
   private Void instanceChoice(Dict instance, Spec slot)
   {
-    selected := ns.choice(slot).selections(instance, false)
+    selected := instanceChoiceSelections(instance, slot)
     selected.each |x|
     {
       w("  ").qname(slot.qname).w(" ").qname(x.qname).w(" ;").nl
     }
+  }
+
+  private Spec[] instanceChoiceSelections(Dict instance, Spec slot)
+  {
+    selected := choiceMembers(slot).findAll |Spec candidate->Bool|
+    {
+      markers := candidate.slots.list.findAll |Spec memberSlot->Bool| { memberSlot.isMarker }
+      return markers.all |Spec marker->Bool| { instance.has(marker.name) }
+    }
+    return XetoUtil.excludeSupertypes(selected)
   }
 
   private Spec instanceSpec(Dict instance)

--- a/src/core/xetom/fan/export/RdfExporter.fan
+++ b/src/core/xetom/fan/export/RdfExporter.fan
@@ -855,13 +855,14 @@ class RdfExporter : Exporter
   {
     val := slot.meta[name]
     if (val == null) return null
-    if (val is Int) return val.toStr
+    context := "${slot.qname}.${name}"
+    if (val is Int) return decimalLexical(val.toStr, context)
     if (val is Float)
     {
       float := (Float)val
       if (float.isNaN || float == Float.posInf || float == Float.negInf)
         throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: non-finite Float")
-      return float.toStr
+      return decimalLexical(float.toStr, context)
     }
     num := val as Number
     if (num == null)
@@ -870,27 +871,29 @@ class RdfExporter : Exporter
       throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: unit-bearing Number")
     if (num.isSpecial)
       throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: non-finite Number")
-    return num.toStr
+    return decimalLexical(num.toStr, context)
   }
 
   private Str? quantityNumericMeta(Spec slot, Str name)
   {
     val := slot.meta[name]
     if (val == null) return null
-    if (val is Int) return val.toStr
+    context := "${slot.qname}.${name}"
+    if (val is Int) return decimalLexical(val.toStr, context)
     if (val is Float)
     {
       float := (Float)val
       if (float.isNaN || float == Float.posInf || float == Float.negInf)
         throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: non-finite Float")
-      return float.toStr
+      return decimalLexical(float.toStr, context)
     }
     num := val as Number
     if (num == null)
       throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: ${val.typeof}")
     if (num.isSpecial)
       throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: non-finite Number")
-    return num.isInt ? num.toInt.toStr : num.toFloat.toStr
+    source := num.isInt ? num.toInt.toStr : num.toFloat.toStr
+    return decimalLexical(source, context)
   }
 
   private Int? intMeta(Spec slot, Str name)
@@ -945,9 +948,12 @@ class RdfExporter : Exporter
     {
       if (val is Int) return val.toStr
       num := val as Number
-      if (num == null || num.unit != null || num.isSpecial)
+      if (num != null && num.isSpecial)
+        throw UnsupportedErr("Invalid RDF decimal for ${context}: non-finite Number")
+      if (num == null || num.unit != null)
         throw UnsupportedErr("Expected finite unitless Number for ${context}, not ${val.typeof}")
-      return num.isInt ? num.toInt.toStr : num.toFloat.toStr
+      source := num.isInt ? num.toInt.toStr : num.toFloat.toStr
+      return decimalLexical(source, context)
     }
 
     if (qname == "sys::Bool")
@@ -1240,7 +1246,8 @@ class RdfExporter : Exporter
     unit := num.unit ?: throw UnsupportedErr("Expected unit-bearing Number for ${property}")
     if (num.isSpecial)
       throw UnsupportedErr("RDF decimal quantity value must be finite for ${property}")
-    value := num.isInt ? num.toInt.toStr : num.toFloat.toStr
+    source := num.isInt ? num.toInt.toStr : num.toFloat.toStr
+    value := decimalLexical(source, property)
     w(indent).qname(property).w(" [").nl
     w(indent).w("  a qudt:QuantityValue ;").nl
     w(indent).w("  qudt:numericValue ").literal(value).w("^^xsd:decimal ;").nl
@@ -1442,9 +1449,7 @@ class RdfExporter : Exporter
     // Keep ordinary Xeto qnames readable. Ref ids may also contain schemes
     // such as `op:name` and `filetype:json`; those are legal RDF fragments
     // but not legal prefixed names, so write their full versioned IRI.
-    if (!local.contains(":") && !local.contains(" ") && !local.contains("\t") &&
-        !local.contains("\r") && !local.contains("\n") && !local.contains("<") &&
-        !local.contains(">") && !local.contains("\"") && !local.contains("\\"))
+    if (isSafePrefixedLocal(local))
       return w(libName).w(":").w(local)
 
     encoded := Uri.encodeToken(local, Uri.sectionFrag)
@@ -1494,22 +1499,119 @@ class RdfExporter : Exporter
     }
   }
 
-  ** Quoted string literal
-  private This literal(Str s)
+  ** Return true when a local name can follow a Turtle prefix without escaping.
+  private Bool isSafePrefixedLocal(Str local)
   {
-    lines := s.splitLines
-    if (lines.size <= 1)
+    if (local.isEmpty || local.endsWith(".")) return false
+    return local.all |char, index|
     {
-      w(lines[0].toCode('"').replace(Str<|\$|>, Str<|$|>))
+      if (char.isAlphaNum && char < 128) return true
+      if (char == '_') return true
+      if (index > 0 && (char == '-' || char == '.')) return true
+      return false
+    }
+  }
+
+  ** Validate a decimal lexical form and expand exponent notation without
+  ** parsing the value through another binary floating-point conversion.
+  private Str decimalLexical(Str source, Str context)
+  {
+    if (source.isEmpty)
+      throw UnsupportedErr("Invalid RDF decimal for ${context}: ${source}")
+
+    negative := source[0] == '-'
+    hasSign := negative || source[0] == '+'
+    unsigned := hasSign ? (source.size == 1 ? "" : source[1..-1]) : source
+    if (unsigned.isEmpty)
+      throw UnsupportedErr("Invalid RDF decimal for ${context}: ${source}")
+
+    lowerExp := unsigned.index("e")
+    upperExp := unsigned.index("E")
+    if (lowerExp != null && upperExp != null)
+      throw UnsupportedErr("Invalid RDF decimal for ${context}: ${source}")
+    expIndex := lowerExp ?: upperExp
+    exponent := 0
+    mantissa := unsigned
+    if (expIndex != null)
+    {
+      mantissa = expIndex == 0 ? "" : unsigned[0..<expIndex]
+      exponentText := expIndex == unsigned.size-1 ? "" : unsigned[expIndex+1..-1]
+      exponentVal := exponentText.toInt(10, false)
+      if (exponentVal == null || exponentVal.abs > maxDecimalDigits)
+        throw UnsupportedErr("Invalid RDF decimal for ${context}: ${source}")
+      exponent = exponentVal
+    }
+
+    dot := mantissa.index(".")
+    if (dot != null && mantissa.index(".", dot+1) != null)
+      throw UnsupportedErr("Invalid RDF decimal for ${context}: ${source}")
+    integer := dot == null ? mantissa : (dot == 0 ? "" : mantissa[0..<dot])
+    fraction := dot == null || dot == mantissa.size-1 ? "" : mantissa[dot+1..-1]
+    if (integer.isEmpty && fraction.isEmpty)
+      throw UnsupportedErr("Invalid RDF decimal for ${context}: ${source}")
+    digits := integer + fraction
+    if (!digits.all |char| { char.isDigit })
+      throw UnsupportedErr("Invalid RDF decimal for ${context}: ${source}")
+
+    decimalPos := integer.size + exponent
+    if (decimalPos.abs > maxDecimalDigits || digits.size > maxDecimalDigits)
+      throw UnsupportedErr("RDF decimal expansion is too large for ${context}")
+
+    if (decimalPos <= 0)
+    {
+      integer = "0"
+      fraction = decimalZeroes(-decimalPos) + digits
+    }
+    else if (decimalPos >= digits.size)
+    {
+      integer = digits + decimalZeroes(decimalPos - digits.size)
+      fraction = ""
     }
     else
     {
-      indent := "    "
-      w(Str<|"""|>).nl
-      lines.each |line| { w(indent).w(line.toCode(null).replace(Str<|\$|>, Str<|$|>)).nl }
-      w("    ").w(Str<|"""|>)
+      integer = digits[0..<decimalPos]
+      fraction = digits[decimalPos..-1]
     }
-    return this
+
+    first := 0
+    while (first < integer.size && integer[first] == '0') first++
+    integer = first == integer.size ? "0" : integer[first..-1]
+    last := fraction.size - 1
+    while (last >= 0 && fraction[last] == '0') last--
+    fraction = last < 0 ? "" : fraction[0..last]
+
+    sign := negative && !(integer == "0" && fraction.isEmpty) ? "-" : ""
+    return fraction.isEmpty ? "${sign}${integer}" : "${sign}${integer}.${fraction}"
+  }
+
+  private Str decimalZeroes(Int count)
+  {
+    buf := StrBuf(count)
+    count.times { buf.addChar('0') }
+    return buf.toStr
+  }
+
+  ** Quoted string literal
+  private This literal(Str s)
+  {
+    wc('"')
+    s.each |char|
+    {
+      switch (char)
+      {
+        case '\b': w("\\b")
+        case '\f': w("\\f")
+        case '\n': w("\\n")
+        case '\r': w("\\r")
+        case '\t': w("\\t")
+        case '\\': w("\\\\")
+        case '"':  w("\\\"")
+        default:
+          if (char <= 0x1f || char == 0x7f) w("\\u").w(char.toHex(4).upper)
+          else wc(char)
+      }
+    }
+    return wc('"')
   }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1517,5 +1619,6 @@ class RdfExporter : Exporter
 //////////////////////////////////////////////////////////////////////////
 
   private Bool isSys
+  private static const Int maxDecimalDigits := 10_000
   private static const Regex queryPathRef := Regex<|(?:[A-Za-z_][A-Za-z0-9_]*|[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*|[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*::[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*)|>
 }

--- a/src/core/xetom/fan/export/RdfExporter.fan
+++ b/src/core/xetom/fan/export/RdfExporter.fan
@@ -557,18 +557,18 @@ class RdfExporter : Exporter
     w("      sh:class qudt:QuantityValue ;").nl
     w("      sh:property [").nl
     w("        sh:path qudt:numericValue ;").nl
-    w("        sh:datatype xsd:decimal ;").nl
+    w("        sh:datatype xsd:double ;").nl
 
     minVal := quantityNumericMeta(slot, "minVal")
-    if (minVal != null) w("        sh:minInclusive ").w(minVal).w(" ;").nl
+    if (minVal != null) w("        sh:minInclusive ").literal(minVal).w("^^xsd:double ;").nl
     maxVal := quantityNumericMeta(slot, "maxVal")
-    if (maxVal != null) w("        sh:maxInclusive ").w(maxVal).w(" ;").nl
+    if (maxVal != null) w("        sh:maxInclusive ").literal(maxVal).w("^^xsd:double ;").nl
     if (slot.meta.has("invariant"))
     {
-      val := quantityNumericMeta(slot, "val")
+      val := quantityNumericMeta(slot, "val", false)
       if (val == null)
         throw UnsupportedErr("Invariant quantity slot ${slot.qname} is missing val metadata")
-      w("        sh:hasValue ").literal(val).w("^^xsd:decimal ;").nl
+      w("        sh:hasValue ").literal(val).w("^^xsd:double ;").nl
     }
     w("        sh:minCount 1 ;").nl
     w("        sh:maxCount 1 ;").nl
@@ -776,7 +776,7 @@ class RdfExporter : Exporter
     switch (type.qname)
     {
       case "sys::Str":      return "xsd:string"
-      case "sys::Number":   return "xsd:decimal"
+      case "sys::Number":   return "xsd:double"
       case "sys::Float":    return "xsd:double"
       case "sys::Int":      return "xsd:integer"
       case "sys::Bool":     return "xsd:boolean"
@@ -883,49 +883,35 @@ class RdfExporter : Exporter
       num := val as Number
       if (num == null || num.unit != null)
         throw UnsupportedErr("Invalid numeric metadata for ${context}: ${val.typeof}")
-      lexical := doubleLexical(num.toStr, context)
+      lexical := doubleLexical(num.toFloat.toStr, context)
       if (lexical == "NaN")
         throw UnsupportedErr("Invalid numeric metadata for ${context}: NaN is not an ordered bound")
       return lexical
     }
-    if (val is Int) return decimalLexical(val.toStr, context)
-    if (val is Float)
-    {
-      float := (Float)val
-      if (float.isNaN || float == Float.posInf || float == Float.negInf)
-        throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: non-finite Float")
-      return decimalLexical(float.toStr, context)
-    }
-    num := val as Number
-    if (num == null)
-      throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: ${val.typeof}")
-    if (num.unit != null)
-      throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: unit-bearing Number")
-    if (num.isSpecial)
-      throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: non-finite Number")
-    return decimalLexical(num.toStr, context)
+    if (datatype == "xsd:integer") return intMeta(slot, name)?.toStr
+    throw UnsupportedErr("Invalid numeric metadata datatype for ${context}: ${datatype}")
   }
 
-  private Str? quantityNumericMeta(Spec slot, Str name)
+  private Str? quantityNumericMeta(Spec slot, Str name, Bool ordered := true)
   {
     val := slot.meta[name]
     if (val == null) return null
     context := "${slot.qname}.${name}"
-    if (val is Int) return decimalLexical(val.toStr, context)
+    if (val is Int) return doubleLexical(val.toStr, context)
     if (val is Float)
     {
-      float := (Float)val
-      if (float.isNaN || float == Float.posInf || float == Float.negInf)
-        throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: non-finite Float")
-      return decimalLexical(float.toStr, context)
+      lexical := doubleLexical(val.toStr, context)
+      if (ordered && lexical == "NaN")
+        throw UnsupportedErr("Invalid numeric metadata for ${context}: NaN is not an ordered bound")
+      return lexical
     }
     num := val as Number
     if (num == null)
       throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: ${val.typeof}")
-    if (num.isSpecial)
-      throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: non-finite Number")
-    source := num.isInt ? num.toInt.toStr : num.toFloat.toStr
-    return decimalLexical(source, context)
+    lexical := doubleLexical(num.toFloat.toStr, context)
+    if (ordered && lexical == "NaN")
+      throw UnsupportedErr("Invalid numeric metadata for ${context}: NaN is not an ordered bound")
+    return lexical
   }
 
   private Int? intMeta(Spec slot, Str name)
@@ -978,14 +964,11 @@ class RdfExporter : Exporter
 
     if (qname == "sys::Number")
     {
-      if (val is Int) return val.toStr
+      if (val is Int) return doubleLexical(val.toStr, context)
       num := val as Number
-      if (num != null && num.isSpecial)
-        throw UnsupportedErr("Invalid RDF decimal for ${context}: non-finite Number")
       if (num == null || num.unit != null)
-        throw UnsupportedErr("Expected finite unitless Number for ${context}, not ${val.typeof}")
-      source := num.isInt ? num.toInt.toStr : num.toFloat.toStr
-      return decimalLexical(source, context)
+        throw UnsupportedErr("Expected unitless Number for ${context}, not ${val.typeof}")
+      return doubleLexical(num.toFloat.toStr, context)
     }
 
     if (qname == "sys::Float")
@@ -996,7 +979,7 @@ class RdfExporter : Exporter
       num := val as Number
       if (num == null || num.unit != null)
         throw UnsupportedErr("Expected unitless Float for ${context}, not ${val.typeof}")
-      return doubleLexical(num.toStr, context)
+      return doubleLexical(num.toFloat.toStr, context)
     }
 
     if (qname == "sys::Bool")
@@ -1287,13 +1270,10 @@ class RdfExporter : Exporter
   private Void instanceQuantityValue(Str property, Number num, Str indent)
   {
     unit := num.unit ?: throw UnsupportedErr("Expected unit-bearing Number for ${property}")
-    if (num.isSpecial)
-      throw UnsupportedErr("RDF decimal quantity value must be finite for ${property}")
-    source := num.isInt ? num.toInt.toStr : num.toFloat.toStr
-    value := decimalLexical(source, property)
+    value := doubleLexical(num.toFloat.toStr, property)
     w(indent).qname(property).w(" [").nl
     w(indent).w("  a qudt:QuantityValue ;").nl
-    w(indent).w("  qudt:numericValue ").literal(value).w("^^xsd:decimal ;").nl
+    w(indent).w("  qudt:numericValue ").literal(value).w("^^xsd:double ;").nl
     w(indent).w("  qudt:unit ").w(qudt.unit(unit)).nl
     w(indent).w("] ;").nl
   }
@@ -1555,135 +1535,18 @@ class RdfExporter : Exporter
     }
   }
 
-  ** Validate a decimal lexical form and expand exponent notation without
-  ** parsing the value through another binary floating-point conversion.
-  private Str decimalLexical(Str source, Str context)
-  {
-    if (source.isEmpty)
-      throw UnsupportedErr("Invalid RDF decimal for ${context}: ${source}")
-
-    negative := source[0] == '-'
-    hasSign := negative || source[0] == '+'
-    unsigned := hasSign ? (source.size == 1 ? "" : source[1..-1]) : source
-    if (unsigned.isEmpty)
-      throw UnsupportedErr("Invalid RDF decimal for ${context}: ${source}")
-
-    lowerExp := unsigned.index("e")
-    upperExp := unsigned.index("E")
-    if (lowerExp != null && upperExp != null)
-      throw UnsupportedErr("Invalid RDF decimal for ${context}: ${source}")
-    expIndex := lowerExp ?: upperExp
-    exponent := 0
-    mantissa := unsigned
-    if (expIndex != null)
-    {
-      mantissa = expIndex == 0 ? "" : unsigned[0..<expIndex]
-      exponentText := expIndex == unsigned.size-1 ? "" : unsigned[expIndex+1..-1]
-      exponentVal := exponentText.toInt(10, false)
-      if (exponentVal == null || exponentVal.abs > maxDecimalDigits)
-        throw UnsupportedErr("Invalid RDF decimal for ${context}: ${source}")
-      exponent = exponentVal
-    }
-
-    dot := mantissa.index(".")
-    if (dot != null && mantissa.index(".", dot+1) != null)
-      throw UnsupportedErr("Invalid RDF decimal for ${context}: ${source}")
-    integer := dot == null ? mantissa : (dot == 0 ? "" : mantissa[0..<dot])
-    fraction := dot == null || dot == mantissa.size-1 ? "" : mantissa[dot+1..-1]
-    if (integer.isEmpty && fraction.isEmpty)
-      throw UnsupportedErr("Invalid RDF decimal for ${context}: ${source}")
-    digits := integer + fraction
-    if (!digits.all |char| { char.isDigit })
-      throw UnsupportedErr("Invalid RDF decimal for ${context}: ${source}")
-
-    decimalPos := integer.size + exponent
-    if (decimalPos.abs > maxDecimalDigits || digits.size > maxDecimalDigits)
-      throw UnsupportedErr("RDF decimal expansion is too large for ${context}")
-
-    if (decimalPos <= 0)
-    {
-      integer = "0"
-      fraction = decimalZeroes(-decimalPos) + digits
-    }
-    else if (decimalPos >= digits.size)
-    {
-      integer = digits + decimalZeroes(decimalPos - digits.size)
-      fraction = ""
-    }
-    else
-    {
-      integer = digits[0..<decimalPos]
-      fraction = digits[decimalPos..-1]
-    }
-
-    first := 0
-    while (first < integer.size && integer[first] == '0') first++
-    integer = first == integer.size ? "0" : integer[first..-1]
-    last := fraction.size - 1
-    while (last >= 0 && fraction[last] == '0') last--
-    fraction = last < 0 ? "" : fraction[0..last]
-
-    sign := negative && !(integer == "0" && fraction.isEmpty) ? "-" : ""
-    return fraction.isEmpty ? "${sign}${integer}" : "${sign}${integer}.${fraction}"
-  }
-
-  private Str decimalZeroes(Int count)
-  {
-    buf := StrBuf(count)
-    count.times { buf.addChar('0') }
-    return buf.toStr
-  }
-
-  ** Validate one Xeto Float and use a stable xsd:double lexical form.
+  ** Parse one Xeto Number through Fantom's binary Float value and use its
+  ** stable shortest round-trippable spelling as the xsd:double lexical form.
   private Str doubleLexical(Str source, Str context)
   {
     if (source == "NaN" || source == "INF" || source == "-INF") return source
-    if (source.isEmpty)
+    value := Float.fromStr(source, false)
+    if (value == null)
       throw UnsupportedErr("Invalid RDF double for ${context}: ${source}")
-
-    negative := source[0] == '-'
-    hasSign := negative || source[0] == '+'
-    unsigned := hasSign ? (source.size == 1 ? "" : source[1..-1]) : source
-    if (unsigned.isEmpty)
-      throw UnsupportedErr("Invalid RDF double for ${context}: ${source}")
-
-    lowerExp := unsigned.index("e")
-    upperExp := unsigned.index("E")
-    if (lowerExp != null && upperExp != null)
-      throw UnsupportedErr("Invalid RDF double for ${context}: ${source}")
-    expIndex := lowerExp ?: upperExp
-    exponent := 0
-    mantissa := unsigned
-    if (expIndex != null)
-    {
-      mantissa = expIndex == 0 ? "" : unsigned[0..<expIndex]
-      exponentText := expIndex == unsigned.size-1 ? "" : unsigned[expIndex+1..-1]
-      exponentVal := exponentText.toInt(10, false)
-      if (exponentVal == null)
-        throw UnsupportedErr("Invalid RDF double for ${context}: ${source}")
-      exponent = exponentVal
-    }
-
-    dot := mantissa.index(".")
-    if (dot != null && mantissa.index(".", dot+1) != null)
-      throw UnsupportedErr("Invalid RDF double for ${context}: ${source}")
-    integer := dot == null ? mantissa : (dot == 0 ? "" : mantissa[0..<dot])
-    fraction := dot == null || dot == mantissa.size-1 ? "" : mantissa[dot+1..-1]
-    if (integer.isEmpty && fraction.isEmpty)
-      throw UnsupportedErr("Invalid RDF double for ${context}: ${source}")
-    if (!(integer + fraction).all |char| { char.isDigit })
-      throw UnsupportedErr("Invalid RDF double for ${context}: ${source}")
-
-    first := 0
-    while (first < integer.size && integer[first] == '0') first++
-    integer = first == integer.size ? "0" : integer[first..-1]
-    last := fraction.size - 1
-    while (last >= 0 && fraction[last] == '0') last--
-    fraction = last < 0 ? "" : fraction[0..last]
-
-    sign := negative ? "-" : ""
-    normalized := fraction.isEmpty ? "${sign}${integer}" : "${sign}${integer}.${fraction}"
-    return exponent == 0 ? normalized : "${normalized}E${exponent}"
+    if (value.isNaN) return "NaN"
+    if (value == Float.posInf) return "INF"
+    if (value == Float.negInf) return "-INF"
+    return value.toStr.replace("e", "E")
   }
 
   ** Quoted string literal
@@ -1714,6 +1577,5 @@ class RdfExporter : Exporter
 //////////////////////////////////////////////////////////////////////////
 
   private Bool isSys
-  private static const Int maxDecimalDigits := 10_000
   private static const Regex queryPathRef := Regex<|(?:[A-Za-z_][A-Za-z0-9_]*|[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*|[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*::[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*)|>
 }

--- a/src/core/xetom/fan/export/RdfExporter.fan
+++ b/src/core/xetom/fan/export/RdfExporter.fan
@@ -25,6 +25,12 @@ class RdfExporter : Exporter
 
   new make(MNamespace ns, OutStream out, Dict opts) : super(ns, out, opts)
   {
+    if (opts.has("qudtMappings"))
+    {
+      mappingOpt := opts["qudtMappings"]
+      this.qudtRef = mappingOpt as RdfQudtMappings
+        ?: throw ArgErr("qudtMappings option must be RdfQudtMappings, not ${mappingOpt?.typeof}")
+    }
   }
 
 //////////////////////////////////////////////////////////////////////////
@@ -84,6 +90,11 @@ class RdfExporter : Exporter
     w("@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .").nl
     w("@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .").nl
     w("@prefix sh: <http://www.w3.org/ns/shacl#> .").nl
+    w("@prefix skos: <http://www.w3.org/2004/02/skos/core#> .").nl
+    w("@prefix qudt: <http://qudt.org/schema/qudt/> .").nl
+    w("@prefix unit: <http://qudt.org/vocab/unit/> .").nl
+    w("@prefix currency: <http://qudt.org/vocab/currency/> .").nl
+    w("@prefix quantitykind: <http://qudt.org/vocab/quantitykind/> .").nl
     lib.depends.each |x| { prefixDef(ns.lib(x.name)) }
     prefixDef(lib)
     nl
@@ -222,9 +233,20 @@ class RdfExporter : Exporter
 
     // value type
     type := slot.type
-    isLiteral := (type.isScalar && !type.isRef) || type.qname == "sys::TimeZone"
+    isQuantityValue := isQuantityValueSlot(slot)
+    isLiteral := ((type.isScalar && !type.isRef) || type.qname == "sys::TimeZone") &&
+                 !isQuantityValue && type.qname != "sys::Unit" &&
+                 type.qname != "sys::UnitQuantity"
     datatype := isLiteral ? scalarDatatype(type) : null
-    if (isLiteral)
+    if (type.qname == "sys::Unit")
+    {
+      sh["class"] = "qudt:Unit"
+    }
+    else if (isQuantityValue)
+    {
+      // The scalar's datatype and range move to qudt:numericValue below.
+    }
+    else if (isLiteral)
     {
       sh["datatype"] = datatype
     }
@@ -237,7 +259,7 @@ class RdfExporter : Exporter
     }
     else if (type.isEnum)
     {
-      if (type.qname == "sys::Unit" || type.qname == "sys::UnitQuantity")
+      if (type.qname == "sys::UnitQuantity")
         throw UnsupportedErr("RDF mapping not implemented for ${type.qname}")
       sh["datatype"] = "xsd:string"
     }
@@ -273,11 +295,98 @@ class RdfExporter : Exporter
     w("  sh:property [").nl
     w("    sh:path ").qname(slot.qname).w(" ;").nl
     sh.each |v, n| { w("    sh:").w(n).w(" ").w(v).w(" ;").nl }
-    if (type.isEnum) enumConstraint(type)
+    if (type.isEnum && type.qname != "sys::Unit" && type.qname != "sys::UnitQuantity")
+      enumConstraint(type)
     if (type.isChoice) choiceConstraint(slot)
     if (type.isList) listConstraint(slot)
+    if (type.qname == "sys::Unit")
+    {
+      quantity := metaQuantity(slot)
+      if (quantity != null) quantityKindConstraint(quantity, "    ")
+    }
+    if (isQuantityValue) quantityValueConstraint(slot)
     if (datatype != null) scalarConstraints(slot, datatype)
     w("  ] ;").nl
+  }
+
+  private Bool isQuantityValueSlot(Spec slot)
+  {
+    slot.type.qname == "sys::Number" &&
+      (slot.meta["unit"] != null || slot.meta["quantity"] != null)
+  }
+
+  private Void quantityValueConstraint(Spec slot)
+  {
+    w("    sh:node [").nl
+    w("      sh:class qudt:QuantityValue ;").nl
+    w("      sh:property [").nl
+    w("        sh:path qudt:numericValue ;").nl
+    w("        sh:datatype xsd:decimal ;").nl
+
+    minVal := quantityNumericMeta(slot, "minVal")
+    if (minVal != null) w("        sh:minInclusive ").w(minVal).w(" ;").nl
+    maxVal := quantityNumericMeta(slot, "maxVal")
+    if (maxVal != null) w("        sh:maxInclusive ").w(maxVal).w(" ;").nl
+    if (slot.meta.has("invariant"))
+    {
+      val := quantityNumericMeta(slot, "val")
+      if (val == null)
+        throw UnsupportedErr("Invariant quantity slot ${slot.qname} is missing val metadata")
+      w("        sh:hasValue ").literal(val).w("^^xsd:decimal ;").nl
+    }
+    w("        sh:minCount 1 ;").nl
+    w("        sh:maxCount 1 ;").nl
+    w("      ] ;").nl
+
+    w("      sh:property [").nl
+    w("        sh:path qudt:unit ;").nl
+    w("        sh:class qudt:Unit ;").nl
+    unit := metaUnit(slot)
+    if (unit != null)
+      w("        sh:hasValue ").w(qudt.unit(unit)).w(" ;").nl
+    quantity := metaQuantity(slot)
+    if (quantity != null) quantityKindConstraint(quantity, "        ")
+    w("        sh:minCount 1 ;").nl
+    w("        sh:maxCount 1 ;").nl
+    w("      ]").nl
+    w("    ] ;").nl
+  }
+
+  private Void quantityKindConstraint(UnitQuantity quantity, Str indent)
+  {
+    targets := qudt.quantity(quantity)
+    if (targets.size == 1)
+    {
+      w(indent).w("sh:node [ sh:property [ sh:path ( qudt:hasQuantityKind [ sh:zeroOrMorePath skos:broader ] ) ; sh:hasValue quantitykind:").w(targets.first).w(" ] ] ;").nl
+      return
+    }
+
+    w(indent).w("sh:node [ sh:or (").nl
+    targets.each |target|
+    {
+      w(indent).w("  [ sh:property [ sh:path ( qudt:hasQuantityKind [ sh:zeroOrMorePath skos:broader ] ) ; sh:hasValue quantitykind:").w(target).w(" ] ]").nl
+    }
+    w(indent).w(") ] ;").nl
+  }
+
+  private Unit? metaUnit(Spec slot)
+  {
+    val := slot.meta["unit"]
+    if (val == null) return null
+    unit := val as Unit
+    if (unit != null) return unit
+    if (val is Str) return Unit.fromStr(val)
+    throw UnsupportedErr("Invalid unit metadata for ${slot.qname}: ${val.typeof}")
+  }
+
+  private UnitQuantity? metaQuantity(Spec slot)
+  {
+    val := slot.meta["quantity"]
+    if (val == null) return null
+    quantity := val as UnitQuantity
+    if (quantity != null) return quantity
+    if (val is Str) return UnitQuantity.fromStr(val)
+    throw UnsupportedErr("Invalid quantity metadata for ${slot.qname}: ${val.typeof}")
   }
 
   private Void choiceConstraint(Spec slot)
@@ -323,9 +432,9 @@ class RdfExporter : Exporter
     of := slot.of(false)
     validateListItemType(slot, of)
 
-    minSize := intMeta(slot.meta["minSize"])
+    minSize := intMeta(slot, "minSize")
     if (slot.meta.has("nonEmpty") && (minSize == null || minSize < 1)) minSize = 1
-    maxSize := intMeta(slot.meta["maxSize"])
+    maxSize := intMeta(slot, "maxSize")
     if (of == null && minSize == null && maxSize == null) return
 
     // A Xeto list is one slot value represented by an RDF collection. The
@@ -377,16 +486,16 @@ class RdfExporter : Exporter
   {
     meta := slot.meta
 
-    minVal := numericMeta(meta["minVal"])
+    minVal := numericMeta(slot, "minVal")
     if (minVal != null) w("    sh:minInclusive ").w(minVal).w(" ;").nl
 
-    maxVal := numericMeta(meta["maxVal"])
+    maxVal := numericMeta(slot, "maxVal")
     if (maxVal != null) w("    sh:maxInclusive ").w(maxVal).w(" ;").nl
 
-    minSize := intMeta(meta["minSize"])
+    minSize := intMeta(slot, "minSize")
     if (minSize != null) w("    sh:minLength ").w(minSize).w(" ;").nl
 
-    maxSize := intMeta(meta["maxSize"])
+    maxSize := intMeta(slot, "maxSize")
     if (maxSize != null) w("    sh:maxLength ").w(maxSize).w(" ;").nl
 
     pattern := scalarPattern(slot)
@@ -399,12 +508,11 @@ class RdfExporter : Exporter
     if (meta.has("invariant"))
     {
       val := meta["val"]
-      if (val != null)
-      {
-        w("    sh:hasValue ")
-        typedLiteral(val, datatype)
-        w(" ;").nl
-      }
+      if (val == null)
+        throw UnsupportedErr("Invariant scalar slot ${slot.qname} is missing val metadata")
+      w("    sh:hasValue ")
+      typedLiteral(val, datatype)
+      w(" ;").nl
     }
   }
 
@@ -431,8 +539,10 @@ class RdfExporter : Exporter
 
   private Str? scalarPattern(Spec slot)
   {
-    pattern := slot.meta["pattern"] as Str
-    if (pattern == null) return null
+    patternVal := slot.meta["pattern"]
+    if (patternVal == null) return null
+    pattern := patternVal as Str
+      ?: throw UnsupportedErr("Invalid pattern metadata for ${slot.qname}: ${patternVal.typeof}")
 
     // Built-in scalar patterns describe Xeto's source encoding; they are not
     // additional value constraints. Keep a slot override or a custom scalar's
@@ -440,7 +550,10 @@ class RdfExporter : Exporter
     type := slot.type
     if (isBuiltInScalar(type.qname))
     {
-      typePattern := type.meta["pattern"] as Str
+      typePatternVal := type.meta["pattern"]
+      typePattern := typePatternVal as Str
+      if (typePatternVal != null && typePattern == null)
+        throw UnsupportedErr("Invalid pattern metadata for ${type.qname}: ${typePatternVal.typeof}")
       if (pattern == typePattern) return null
     }
     return pattern
@@ -455,20 +568,60 @@ class RdfExporter : Exporter
     qname == "sys::TimeZone"
   }
 
-  private Str? numericMeta(Obj? val)
+  private Str? numericMeta(Spec slot, Str name)
   {
+    val := slot.meta[name]
+    if (val == null) return null
     if (val is Int) return val.toStr
-    if (val is Float) return val.toStr
+    if (val is Float)
+    {
+      float := (Float)val
+      if (float.isNaN || float == Float.posInf || float == Float.negInf)
+        throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: non-finite Float")
+      return float.toStr
+    }
     num := val as Number
-    if (num == null || num.unit != null) return null
+    if (num == null)
+      throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: ${val.typeof}")
+    if (num.unit != null)
+      throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: unit-bearing Number")
+    if (num.isSpecial)
+      throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: non-finite Number")
     return num.toStr
   }
 
-  private Int? intMeta(Obj? val)
+  private Str? quantityNumericMeta(Spec slot, Str name)
   {
+    val := slot.meta[name]
+    if (val == null) return null
+    if (val is Int) return val.toStr
+    if (val is Float)
+    {
+      float := (Float)val
+      if (float.isNaN || float == Float.posInf || float == Float.negInf)
+        throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: non-finite Float")
+      return float.toStr
+    }
+    num := val as Number
+    if (num == null)
+      throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: ${val.typeof}")
+    if (num.isSpecial)
+      throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: non-finite Number")
+    return num.isInt ? num.toInt.toStr : num.toFloat.toStr
+  }
+
+  private Int? intMeta(Spec slot, Str name)
+  {
+    val := slot.meta[name]
+    if (val == null) return null
     if (val is Int) return val
     num := val as Number
-    if (num == null || num.unit != null || !num.isInt) return null
+    if (num == null)
+      throw UnsupportedErr("Invalid integer metadata for ${slot.qname}.${name}: ${val.typeof}")
+    if (num.unit != null)
+      throw UnsupportedErr("Invalid integer metadata for ${slot.qname}.${name}: unit-bearing Number")
+    if (!num.isInt)
+      throw UnsupportedErr("Invalid integer metadata for ${slot.qname}.${name}: non-integer Number")
     return num.toInt
   }
 
@@ -622,7 +775,13 @@ class RdfExporter : Exporter
 
     if (type.isEnum)
     {
-      if (type.qname == "sys::Unit" || type.qname == "sys::UnitQuantity")
+      if (type.qname == "sys::Unit")
+      {
+        unit := val as Unit ?: throw UnsupportedErr("Expected Unit for ${property}, not ${val.typeof}")
+        w(indent).qname(property).w(" ").w(qudt.unit(unit)).w(" ;").nl
+        return
+      }
+      if (type.qname == "sys::UnitQuantity")
         throw UnsupportedErr("RDF mapping not implemented for ${type.qname}")
       key := val.toStr
       if (type.enum.spec(key, false) == null)
@@ -648,7 +807,10 @@ class RdfExporter : Exporter
     {
       num := val as Number
       if (num != null && num.unit != null)
-        throw UnsupportedErr("RDF quantity value mapping not implemented for ${property}")
+      {
+        instanceQuantityValue(property, num, indent)
+        return
+      }
       w(indent).qname(property).w(" ")
       typedLiteral(val, scalarDatatype(type))
       w(" ;").nl
@@ -656,6 +818,19 @@ class RdfExporter : Exporter
     }
 
     throw UnsupportedErr("RDF instance mapping not implemented for ${property} of ${type.qname}")
+  }
+
+  private Void instanceQuantityValue(Str property, Number num, Str indent)
+  {
+    unit := num.unit ?: throw UnsupportedErr("Expected unit-bearing Number for ${property}")
+    if (num.isSpecial)
+      throw UnsupportedErr("RDF decimal quantity value must be finite for ${property}")
+    value := num.isInt ? num.toInt.toStr : num.toFloat.toStr
+    w(indent).qname(property).w(" [").nl
+    w(indent).w("  a qudt:QuantityValue ;").nl
+    w(indent).w("  qudt:numericValue ").literal(value).w("^^xsd:decimal ;").nl
+    w(indent).w("  qudt:unit ").w(qudt.unit(unit)).nl
+    w(indent).w("] ;").nl
   }
 
   private Void instanceMultiRef(Str property, Obj val, Str indent)
@@ -802,6 +977,12 @@ class RdfExporter : Exporter
 //////////////////////////////////////////////////////////////////////////
 
   private Lib? curLib
+  private RdfQudtMappings? qudtRef
+
+  private RdfQudtMappings qudt()
+  {
+    qudtRef ?: (qudtRef = RdfQudtMappings.load(ns))
+  }
 
   ** Convert library to its RDF URI
   private Str libUri(Lib lib)

--- a/src/core/xetom/fan/export/RdfExporter.fan
+++ b/src/core/xetom/fan/export/RdfExporter.fan
@@ -48,6 +48,7 @@ class RdfExporter : Exporter
   {
     this.curLib = lib
     this.isSys = lib.name == "sys"
+    validateNamespaceVersions(lib)
     validateSealedNamespace(lib)
     types := lib.types.list
 
@@ -142,7 +143,7 @@ class RdfExporter : Exporter
       lib.depends.each |x, i|
       {
         if (i > 0) w(",").nl.w(Str.spaces(12))
-        w("<").w(libUri(ns.lib(x.name))).w(">")
+        w("<").w(libUri(requireLibrary(x.name))).w(">")
       }
     }
     nl.w(".").nl
@@ -1378,15 +1379,15 @@ class RdfExporter : Exporter
   }
 
   ** Turn Xeto qname into RDF URI
-  static Str qnameToUri(Str qname)
+  private Str qnameToUri(Str qname)
   {
-    qname.replace("::", ":")
+    requireQNameLibrary(qname, "RDF name")
+    return qname.replace("::", ":")
   }
 
   ** Output Xeto lib::name qualified name
   private This qname(Str qname)
   {
-    validateQName(qname, "RDF name")
     return w(qnameToUri(qname))
   }
 
@@ -1400,9 +1401,7 @@ class RdfExporter : Exporter
 
     libName := qname[0..<sep]
     local := qname[sep + 2..-1]
-    lib := curLib?.name == libName ? curLib : ns.lib(libName, false)
-    if (lib == null)
-      throw UnsupportedErr("RDF instance id or reference uses unknown library ${libName}: ${qname}")
+    lib := requireLibrary(libName)
 
     // Keep ordinary Xeto qnames readable. Ref ids may also contain schemes
     // such as `op:name` and `filetype:json`; those are legal RDF fragments
@@ -1425,6 +1424,38 @@ class RdfExporter : Exporter
       qname.contains("\n") || qname.contains("<") || qname.contains(">") ||
       qname.contains("\"") || qname.contains("\\")
     if (invalid) throw UnsupportedErr("${kind} is not QName-compatible: ${qname}")
+  }
+
+  ** Resolve a qname against the pinned namespace before emitting its prefix.
+  private Lib requireQNameLibrary(Str qname, Str kind)
+  {
+    validateQName(qname, kind)
+    sep := qname.index("::") ?: throw UnsupportedErr("${kind} is not QName-compatible: ${qname}")
+    return requireLibrary(qname[0..<sep])
+  }
+
+  ** Resolve one library to the concrete version selected by this namespace.
+  private Lib requireLibrary(Str name)
+  {
+    lib := curLib?.name == name ? curLib : ns.lib(name, false)
+    if (lib == null)
+      throw UnsupportedErr("Concrete Xeto library version unavailable for ${name}")
+    return lib
+  }
+
+  ** A Namespace promises one pinned version per library. Check that invariant
+  ** explicitly so RDF export also fails closed for custom Namespace providers.
+  private Void validateNamespaceVersions(Lib lib)
+  {
+    selected := Str:Version[:]
+    selected[lib.name] = lib.version
+    ns.versions.each |libVersion|
+    {
+      previous := selected[libVersion.name]
+      if (previous != null && previous != libVersion.version)
+        throw UnsupportedErr("Ambiguous Xeto library version for ${libVersion.name}: ${previous} and ${libVersion.version}")
+      selected[libVersion.name] = libVersion.version
+    }
   }
 
   ** Quoted string literal

--- a/src/core/xetom/fan/export/RdfExporter.fan
+++ b/src/core/xetom/fan/export/RdfExporter.fan
@@ -444,6 +444,7 @@ class RdfExporter : Exporter
     {
       inverse := inverseVal as Str
         ?: throw UnsupportedErr("Invalid inverse metadata for ${query.qname}: ${inverseVal.typeof}")
+      validateQueryPath(query, inverse, false)
       inverseQname := resolveQueryName(query, inverse)
       inverseQuery := resolveSpec(inverseQname)
       if (inverseQuery != null && inverseQuery.isQuery)
@@ -470,16 +471,13 @@ class RdfExporter : Exporter
 
   private Void writeViaPath(Spec query, Str source, Bool inverse)
   {
-    if (source.isEmpty)
-      throw UnsupportedErr("Empty query path for ${query.qname}")
+    validateQueryPath(query, source, true)
 
     quantifier := ""
     if (source.endsWith("+") || source.endsWith("*"))
     {
       quantifier = source[-1].toChar
       source = source[0..-2]
-      if (source.isEmpty)
-        throw UnsupportedErr("Empty query path for ${query.qname}")
     }
 
     property := resolveQueryName(query, source)
@@ -489,6 +487,23 @@ class RdfExporter : Exporter
     qname(property)
     if (inverse) w(" ]")
     if (!quantifier.isEmpty) w(" ]")
+  }
+
+  private Void validateQueryPath(Spec query, Str source, Bool allowQuantifier)
+  {
+    if (source.isEmpty)
+      throw UnsupportedErr("Empty query path for ${query.qname}")
+
+    path := source
+    if (allowQuantifier && (path.endsWith("+") || path.endsWith("*")))
+    {
+      path = path[0..-2]
+      if (path.isEmpty)
+        throw UnsupportedErr("Empty query path for ${query.qname}")
+    }
+
+    if (path.contains("+") || path.contains("*") || !queryPathRef.matches(path))
+      throw UnsupportedErr("Invalid query path for ${query.qname}: ${source}")
   }
 
   ** Resolve an unqualified path relative to the query declaration. A
@@ -1394,4 +1409,5 @@ class RdfExporter : Exporter
 //////////////////////////////////////////////////////////////////////////
 
   private Bool isSys
+  private static const Regex queryPathRef := Regex<|(?:[A-Za-z_][A-Za-z0-9_]*|[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*|[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*::[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*)|>
 }

--- a/src/core/xetom/fan/export/RdfExporter.fan
+++ b/src/core/xetom/fan/export/RdfExporter.fan
@@ -13,7 +13,7 @@ using haystack
 ** RDF Turtle Exporter
 **
 ** TODO
-**   - list and dict slots not supported
+**   - list slots not supported
 **   - query constraints not implemented
 **
 @Js
@@ -44,6 +44,7 @@ class RdfExporter : Exporter
 
   override This lib(Lib lib)
   {
+    this.curLib = lib
     this.isSys = lib.name == "sys"
     types := lib.types.list
 
@@ -150,7 +151,7 @@ class RdfExporter : Exporter
       if (s.isMarker) markers.add(s)
       else props.add(s)
     }
-    hasShape := !props.isEmpty || markers.any |s| { !s.isMaybe }
+    hasShape := !x.isEnum && (!props.isEmpty || markers.any |s| { !s.isMaybe })
 
     qname(x.qname).nl
 
@@ -170,11 +171,11 @@ class RdfExporter : Exporter
     // label and comment properties
     labelAndDoc(x)
 
-    // expand enum items as self-referential class/instances
+    // Enum values are RDF string literals constrained by sh:in; they are not
+    // vocabulary individuals of their own.
     if (x.isEnum)
     {
       w(".").nl
-      enum(x)
       return this
     }
 
@@ -244,22 +245,31 @@ class RdfExporter : Exporter
     else if (type.isRef || type.isMultiRef)
     {
       of := slot.of(false)?.qname ?: "sys::Entity"
+      sh["nodeKind"] = "sh:IRI"
       sh["class"] = qnameToUri(of)
       if (type.isMultiRef) hasMaxCount = false
     }
     else if (type.isEnum)
     {
-      sh["class"] = qnameToUri(type.qname)
+      if (type.qname == "sys::Unit" || type.qname == "sys::UnitQuantity")
+        throw UnsupportedErr("RDF mapping not implemented for ${type.qname}")
+      sh["datatype"] = "xsd:string"
     }
     else if (type.isChoice)
     {
-      sh["class"] = qnameToUri(type.qname)
-      if (slot.meta.has("multiChoice")) hasMaxCount = false
+      throw UnsupportedErr("RDF mapping not implemented for choice slot ${slot.qname}")
+    }
+    else if (type.isDict)
+    {
+      sh["node"] = qnameToUri(type.qname)
+    }
+    else if (type.qname == "sys::Obj")
+    {
+      // Obj deliberately constrains only cardinality.
     }
     else
     {
-      // Preserve the existing fallback for constructs handled by later slices.
-      sh["datatype"] = "xsd:string"
+      throw UnsupportedErr("RDF mapping not implemented for slot ${slot.qname} of ${type.qname}")
     }
 
     // cardinality minCount/maxCount
@@ -270,8 +280,20 @@ class RdfExporter : Exporter
     w("  sh:property [").nl
     w("    sh:path ").qname(slot.qname).w(" ;").nl
     sh.each |v, n| { w("    sh:").w(n).w(" ").w(v).w(" ;").nl }
+    if (type.isEnum) enumConstraint(type)
     if (datatype != null) scalarConstraints(slot, datatype)
     w("  ] ;").nl
+  }
+
+  private Void enumConstraint(Spec type)
+  {
+    w("    sh:in (")
+    type.enum.keys.each |key, i|
+    {
+      if (i > 0) w(" ")
+      literal(key).w("^^xsd:string")
+    }
+    w(") ;").nl
   }
 
   private Void scalarConstraints(Spec slot, Str datatype)
@@ -378,26 +400,6 @@ class RdfExporter : Exporter
     literal(val.toStr).w("^^").w(datatype)
   }
 
-  private This enum(Spec x)
-  {
-    x.enum.each |item, key|
-    {
-      uri := enumItemUri(item)
-      w(uri).nl
-      w("  a sys:Class ;").nl
-      w("  a ").w(uri).w(" ;").nl
-      w("  rdfs:label ").literal(key).w("; ").nl
-      w("  rdfs:subClassOf ").qname(x.qname).w("; ").nl
-      w(".").nl
-    }
-    return this
-  }
-
-  private Str enumItemUri(Spec item)
-  {
-    qnameToUri(item.qname)
-  }
-
   private This global(Spec x)
   {
     // don't generate globals, just class properties
@@ -470,68 +472,142 @@ class RdfExporter : Exporter
     if (id.toStr.startsWith("ph::op:")) return this
     if (id.toStr.startsWith("ph::filetype:")) return this
 
-    spec := ns.specOf(instance)
-    dis := instance.dis.trim
-    members := spec.members
-
-    markers := Str:Spec[:]
-    refs    := Str:Spec[:]
-    enums   := Str:Spec[:]
-    vals    := Str:Spec[:]
-    instance.each |v, n|
-    {
-      if (n == "id") return
-      if (n == "dis" || n == "disMacro") return
-
-      slot := members.get(n, false)
-      if (slot == null) return
-      if (slot.isChoice) return // handled below
-
-      type := slot.type
-      if (v == Marker.val)  markers[n] = slot
-      else if (v is Ref)    refs[n] = slot
-      else if (type.isEnum) enums[n] = slot
-      else vals[n] = slot
-    }
-
+    spec := instanceSpec(instance)
     this.id(id).nl
-    w("  rdf:type ").qname(spec.qname).w(" ;").nl
-    w("  rdfs:label ").literal(dis).w(" ;").nl
-    markers.keys.sort.each |n| { instanceMarker(instance, n, markers[n]) }
-    refs.keys.sort.each  |n| { instanceRef(instance, n, refs[n]) }
-    enums.keys.sort.each |n| { instanceEnum(instance, n, enums[n]) }
-    vals.keys.sort.each  |n| { instanceVal(instance, n, vals[n]) }
+    w("  a ").w(isSys ? ":Entity" : "sys:Entity").w(", ").qname(spec.qname).w(" ;").nl
+    instanceMembers(instance, spec, "  ")
     spec.slots.each |s| { if (s.isChoice) instanceChoice(instance, s) }
     w(".").nl
     return this
   }
 
-  private Void instanceMarker(Dict instance, Str name, Spec slot)
+  private Void instanceMembers(Dict instance, Spec spec, Str indent)
   {
-    w("  sys:hasMarker ").qname(slot.qname).w(" ;").nl
+    members := ns.reflect(instance, spec).members.dup
+    members.sort |a, b| { instanceProperty(spec, a) <=> instanceProperty(spec, b) }
+    members.each |member|
+    {
+      if (member.name == "id" || member.name == "spec" || member.isChoice) return
+
+      val := member.val
+      slot := member.spec
+      if (val == null && slot.isSlot && slot.metaOwn.has("val")) val = slot.metaOwn["val"]
+      if (val == null) return
+
+      property := instanceProperty(spec, member)
+      type := slot.isSlot ? slot.type : slot
+      instanceMember(property, type, val, indent)
+    }
   }
 
-  private Void instanceRef(Dict instance, Str name, Spec slot)
+  private Str instanceProperty(Spec parent, ReflectMember member)
   {
-    ref := instance[name]
-    if (ref == null) return
-    w("  ").qname(slot.qname).w(" ").id(ref).w(" ;").nl
+    spec := member.spec
+    return spec.isSlot ? spec.qname : "${parent.qname}.${member.name}"
   }
 
-  private Void instanceEnum(Dict instance, Str name, Spec slot)
+  private Void instanceMember(Str property, Spec type, Obj val, Str indent)
   {
-    key := instance[name]?.toStr
-    if (key == null) return
-    item := slot.type.enum.spec(key, false)
-    if (item == null) return
-    w("  ").qname(slot.qname).w(" ").w(enumItemUri(item)).w(" ;").nl
+    if (val == Marker.val)
+    {
+      w(indent).w(isSys ? ":hasMarker" : "sys:hasMarker").w(" ").qname(property).w(" ;").nl
+      return
+    }
+
+    if (type.isRef)
+    {
+      ref := val as Ref ?: throw UnsupportedErr("Expected Ref for ${property}, not ${val.typeof}")
+      w(indent).qname(property).w(" ").id(ref).w(" ;").nl
+      return
+    }
+
+    if (type.isMultiRef)
+    {
+      instanceMultiRef(property, val, indent)
+      return
+    }
+
+    if (type.isEnum)
+    {
+      if (type.qname == "sys::Unit" || type.qname == "sys::UnitQuantity")
+        throw UnsupportedErr("RDF mapping not implemented for ${type.qname}")
+      key := val.toStr
+      if (type.enum.spec(key, false) == null)
+        throw UnsupportedErr("Invalid ${type.qname} value: ${key}")
+      w(indent).qname(property).w(" ").literal(key).w("^^xsd:string ;").nl
+      return
+    }
+
+    if (type.isDict)
+    {
+      nested := val as Dict ?: throw UnsupportedErr("Expected Dict for ${property}, not ${val.typeof}")
+      instanceNested(property, nested, indent)
+      return
+    }
+
+    if (type.isScalar && !type.isRef)
+    {
+      num := val as Number
+      if (num != null && num.unit != null)
+        throw UnsupportedErr("RDF quantity value mapping not implemented for ${property}")
+      w(indent).qname(property).w(" ")
+      typedLiteral(val, scalarDatatype(type))
+      w(" ;").nl
+      return
+    }
+
+    throw UnsupportedErr("RDF instance mapping not implemented for ${property} of ${type.qname}")
   }
 
-  private Void instanceVal(Dict instance, Str name, Spec slot)
+  private Void instanceMultiRef(Str property, Obj val, Str indent)
   {
-    val := instance[name]
-    if (val == null) return
-    w("  ").qname(slot.qname).w(" ").literal(val.toStr).w(" ;").nl
+    if (val is Ref)
+    {
+      instanceRefValue(property, val, indent)
+      return
+    }
+
+    refs := val as List
+    if (refs != null)
+    {
+      refs.each |item|
+      {
+        ref := item as Ref ?: throw UnsupportedErr("Expected Ref item for ${property}, not ${item.typeof}")
+        instanceRefValue(property, ref, indent)
+      }
+      return
+    }
+
+    // Source-declared MultiRef blocks remain Dicts in Lib.instances; their
+    // generated slots carry the same refs returned by instantiated Ref[].
+    dict := val as Dict ?: throw UnsupportedErr("Expected Ref, Ref[], or MultiRef Dict for ${property}, not ${val.typeof}")
+    dict.each |item, name|
+    {
+      if (name == "id" || name == "spec") return
+      ref := item as Ref ?: throw UnsupportedErr("Expected Ref item for ${property}.${name}, not ${item.typeof}")
+      instanceRefValue(property, ref, indent)
+    }
+  }
+
+  private Void instanceRefValue(Str property, Ref ref, Str indent)
+  {
+    w(indent).qname(property).w(" ").id(ref).w(" ;").nl
+  }
+
+  private Void instanceNested(Str property, Dict nested, Str indent)
+  {
+    nestedId := nested["id"] as Ref
+    if (nestedId != null)
+    {
+      w(indent).qname(property).w(" ").id(nestedId).w(" ;").nl
+      return
+    }
+
+    nestedSpec := instanceSpec(nested)
+    w(indent).qname(property).w(" [").nl
+    w(indent).w("  a ").qname(nestedSpec.qname).w(" ;").nl
+    instanceMembers(nested, nestedSpec, indent + "  ")
+    w(indent).w("] ;").nl
   }
 
   private Void instanceChoice(Dict instance, Spec slot)
@@ -543,9 +619,25 @@ class RdfExporter : Exporter
     }
   }
 
+  private Spec instanceSpec(Dict instance)
+  {
+    spec := ns.specOf(instance, false)
+    if (spec != null) return spec
+
+    specRef := instance["spec"] as Ref
+    qname := specRef?.toStr
+    lib := curLib
+    if (qname != null && lib != null && qname.startsWith("${lib.name}::"))
+      return lib.spec(qname[qname.index("::") + 2..-1])
+
+    throw UnknownSpecErr(qname ?: instance.typeof.qname)
+  }
+
 //////////////////////////////////////////////////////////////////////////
 // Utils
 //////////////////////////////////////////////////////////////////////////
+
+  private Lib? curLib
 
   ** Convert library to its RDF URI
   private Str libUri(Lib lib)

--- a/src/core/xetom/fan/export/RdfExporter.fan
+++ b/src/core/xetom/fan/export/RdfExporter.fan
@@ -196,7 +196,8 @@ class RdfExporter : Exporter
       if (s.isMarker) markers.add(s)
       else props.add(s)
     }
-    hasShape := !x.isEnum && (!props.isEmpty || markers.any |s| { !s.isMaybe })
+    hasShape := !x.isEnum &&
+                ((x.isCompound && x.isOr) || !props.isEmpty || markers.any |s| { !s.isMaybe })
 
     qname(x.qname).nl
 
@@ -242,6 +243,12 @@ class RdfExporter : Exporter
     if (hasShape)
     {
       w("  sh:targetClass ").qname(x.qname).w(" ;").nl
+      if (x.isCompound && x.isOr)
+      {
+        w("  sh:or (").nl
+        x.bases.each |member| { w("    [ sh:class ").qname(member.qname).w(" ]").nl }
+        w("  ) ;").nl
+      }
       props.each |s| { propShape(s) }
       markers.each |s| { if (!s.isMaybe) markerShape(s) }
     }
@@ -1008,7 +1015,7 @@ class RdfExporter : Exporter
 
     if (qname == "sys::DateTime")
     {
-      if (val is DateTime) return val.toStr
+      if (val is DateTime) return ((DateTime)val).toIso
       str := val as Str
       if (str != null && DateTime.fromStr(str, false) != null) return str
       throw UnsupportedErr("Expected DateTime for ${context}, not ${val.typeof}")

--- a/src/core/xetom/fan/export/RdfExporter.fan
+++ b/src/core/xetom/fan/export/RdfExporter.fan
@@ -686,23 +686,36 @@ class RdfExporter : Exporter
     maxSize := intMeta(slot, "maxSize")
     if (of == null && minSize == null && maxSize == null) return
 
-    // A Xeto list is one slot value represented by an RDF collection. The
-    // outer property shape handles list presence/cardinality; this nested
-    // shape applies item type and size constraints along rdf:rest*/rdf:first.
+    // A Xeto list is one slot value represented by an RDF collection. Validate
+    // item values through rdf:first, but count rdf:rest nodes for size so equal
+    // item values do not collapse under SHACL property-path set semantics.
     w("    sh:node [").nl
-    w("      sh:property [").nl
-    w("        sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;").nl
     if (of != null)
     {
+      w("      sh:property [").nl
+      w("        sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;").nl
       if (of.isScalar)
         w("        sh:datatype ").w(scalarDatatype(of)).w(" ;").nl
       else if (of.isDict)
         w("        sh:class ").qname(of.qname).w(" ;").nl
+      w("      ] ;").nl
     }
-    if (minSize != null) w("        sh:minCount ").w(minSize).w(" ;").nl
-    if (maxSize != null) w("        sh:maxCount ").w(maxSize).w(" ;").nl
-    w("      ]").nl
+    if (minSize != null || maxSize != null)
+    {
+      w("      sh:property [").nl
+      w("        sh:path [ sh:zeroOrMorePath rdf:rest ] ;").nl
+      if (minSize != null) w("        sh:minCount ").w(listNodeCount(slot, "minSize", minSize)).w(" ;").nl
+      if (maxSize != null) w("        sh:maxCount ").w(listNodeCount(slot, "maxSize", maxSize)).w(" ;").nl
+      w("      ] ;").nl
+    }
     w("    ] ;").nl
+  }
+
+  private Int listNodeCount(Spec slot, Str name, Int size)
+  {
+    if (size == Int.maxVal)
+      throw UnsupportedErr("${name} is too large for RDF list-node counting on ${slot.qname}")
+    return size + 1
   }
 
   private Void validateListItemType(Spec slot, Spec? of)

--- a/src/core/xetom/fan/export/RdfExporter.fan
+++ b/src/core/xetom/fan/export/RdfExporter.fan
@@ -369,7 +369,7 @@ class RdfExporter : Exporter
     else if (type.isEnum)
     {
       if (type.qname == "sys::UnitQuantity")
-        throw UnsupportedErr("RDF mapping not implemented for ${type.qname}")
+        throw UnsupportedErr("RDF UnitQuantity mapping not supported for ${slot.qname} of ${type.qname}")
       sh["datatype"] = "xsd:string"
     }
     else if (type.isChoice)
@@ -393,7 +393,7 @@ class RdfExporter : Exporter
     }
     else
     {
-      throw UnsupportedErr("RDF mapping not implemented for slot ${slot.qname} of ${type.qname}")
+      throw UnsupportedErr("RDF slot type mapping not supported for ${slot.qname} of ${type.qname}")
     }
 
     // cardinality minCount/maxCount
@@ -676,8 +676,9 @@ class RdfExporter : Exporter
     // The current public mapping defines scalar and direct-dictionary items.
     // Deferred forms fail closed instead of being omitted or stringified.
     kind := "item type ${of.qname}"
-    if (of.isEnum) kind = "enum item type ${of.qname}"
-    else if (of.isChoice) kind = "choice item type ${of.qname}"
+    if (of.isChoice) kind = "choice item type ${of.qname}"
+    else if (of.qname == "sys::Unit") kind = "unit item type ${of.qname}"
+    else if (of.isEnum) kind = "enum item type ${of.qname}"
     else if (of.isRef || of.isMultiRef) kind = "reference item type ${of.qname}"
     else if (of.isList) kind = "nested-list item type ${of.qname}"
     else if (of.isScalar || of.isDict) return
@@ -1092,7 +1093,7 @@ class RdfExporter : Exporter
         return
       }
       if (type.qname == "sys::UnitQuantity")
-        throw UnsupportedErr("RDF mapping not implemented for ${type.qname}")
+        throw UnsupportedErr("RDF UnitQuantity mapping not supported for ${property} of ${type.qname}")
       scalar := val as Scalar
         ?: throw UnsupportedErr("Expected ${type.qname} enum value for ${property}, not ${val.typeof}")
       if (scalar.qname != type.qname)
@@ -1140,7 +1141,7 @@ class RdfExporter : Exporter
       return
     }
 
-    throw UnsupportedErr("RDF instance mapping not implemented for ${property} of ${type.qname}")
+    throw UnsupportedErr("RDF instance value mapping not supported for ${property} of ${type.qname}")
   }
 
   private Void instanceQuantityValue(Str property, Number num, Str indent)
@@ -1236,7 +1237,7 @@ class RdfExporter : Exporter
     {
       num := item as Number
       if (num != null && num.unit != null)
-        throw UnsupportedErr("RDF quantity list item mapping not implemented for ${property}")
+        throw UnsupportedErr("RDF quantity list item mapping not supported for ${property}")
       typedLiteral(item, type, property)
       return
     }

--- a/src/core/xetom/fan/export/RdfExporter.fan
+++ b/src/core/xetom/fan/export/RdfExporter.fan
@@ -22,6 +22,10 @@ class RdfExporter : Exporter
 
   new make(MNamespace ns, OutStream out, Dict opts) : super(ns, out, opts)
   {
+    this.instancesOnly = opts.has("instancesOnly")
+    this.schemaOnly = opts.has("schemaOnly")
+    if (instancesOnly && schemaOnly)
+      throw ArgErr("instancesOnly and schemaOnly are mutually exclusive")
     if (opts.has("qudtMappings"))
     {
       mappingOpt := opts["qudtMappings"]
@@ -49,10 +53,15 @@ class RdfExporter : Exporter
     this.curLib = lib
     this.isSys = lib.name == "sys"
     validateNamespaceVersions(lib)
+    prefixDefs(lib)
+    if (instancesOnly)
+    {
+      lib.instances.each |x| { instance(x) }
+      return this
+    }
+
     validateSealedNamespace(lib)
     types := lib.types.list
-
-    prefixDefs(lib)
     ontologyDef(lib)
 
     if (isSys)
@@ -86,7 +95,7 @@ class RdfExporter : Exporter
       if (target == null) throw UnsupportedErr("Mixin target not found: ${targetQname}")
       mixinShape(target, contributions)
     }
-    lib.instances.each |x| { instance(x) }
+    if (!schemaOnly) lib.instances.each |x| { instance(x) }
     return this
   }
 
@@ -707,7 +716,7 @@ class RdfExporter : Exporter
   private Void enumConstraint(Spec type)
   {
     w("    sh:in (")
-    type.enum.keys.each |key, i|
+    type.enum.keys.sort.each |key, i|
     {
       if (i > 0) w(" ")
       literal(key).w("^^xsd:string")
@@ -1095,15 +1104,40 @@ class RdfExporter : Exporter
 
       val := member.val
       slot := member.spec
-      if (val == null && slot.isSlot && slot.metaOwn.has("val")) val = slot.metaOwn["val"]
+      // Global-slot reflection may expose the declaration without carrying the
+      // value already materialized on the completed instance dictionary.
+      if (val == null && instance.has(member.name)) val = instance[member.name]
+      if (val == null && !slot.isMaybe &&
+          (slot.type.isScalar || slot.type.isEnum) && slot.meta.has("val"))
+        val = slot.meta["val"]
       if (val == null) return
 
-      property := instanceProperty(spec, member)
+      // The runtime Ref type uses @x as an internal construction placeholder.
+      // Only export it when the instance actually authored that member.
+      ref := val as Ref
+      if (ref != null && ref.id == "x" && !instance.has(member.name)) return
+
       // Parameterized list metadata such as `of` and size constraints lives
       // on the slot spec, not the shared sys::List type.
       type := slot.isSlot && slot.type.isList ? slot : (slot.isSlot ? slot.type : slot)
-      instanceMember(property, type, val, indent)
+      instanceProperties(spec, member).each |property|
+      {
+        instanceMember(property, type, val, indent)
+      }
     }
+  }
+
+  private Str[] instanceProperties(Spec parent, ReflectMember member)
+  {
+    spec := member.spec
+    properties := Str:Bool[:]
+    properties[instanceProperty(parent, member)] = true
+    while (spec.isSlot && spec.base != null && (spec.base.isSlot || spec.base.isGlobal))
+    {
+      spec = spec.base
+      properties[spec.qname] = true
+    }
+    return properties.keys.sort
   }
 
   private Str instanceProperty(Spec parent, ReflectMember member)
@@ -1358,6 +1392,8 @@ class RdfExporter : Exporter
 //////////////////////////////////////////////////////////////////////////
 
   private Lib? curLib
+  private Bool instancesOnly
+  private Bool schemaOnly
   private RdfQudtMappings? qudtRef
 
   private RdfQudtMappings qudt()

--- a/src/core/xetom/fan/export/RdfExporter.fan
+++ b/src/core/xetom/fan/export/RdfExporter.fan
@@ -12,9 +12,6 @@ using haystack
 **
 ** RDF Turtle Exporter
 **
-** TODO
-**   - query constraints not implemented
-**
 @Js
 class RdfExporter : Exporter
 {
@@ -51,6 +48,7 @@ class RdfExporter : Exporter
   {
     this.curLib = lib
     this.isSys = lib.name == "sys"
+    validateSealedNamespace(lib)
     types := lib.types.list
 
     prefixDefs(lib)
@@ -62,8 +60,31 @@ class RdfExporter : Exporter
       types = types.dup.moveTo(types.find { it.name == "Obj" }, 0)
     }
 
-    types.each |x| { if (!XetoUtil.isAutoName(x.name)) cls(x) }
-    lib.mixins.each |x| { if (!XetoUtil.isAutoName(x.name)) cls(x) }
+    types.each |x| { if (!XetoUtil.isAutoName(x.name)) cls(ns.specx(x)) }
+
+    // A mixin contributes to its target's effective shape; it is not an RDF
+    // class of its own. Emit each affected target once with all namespace
+    // mixins applied, while its contributed slots retain their own qnames.
+    mixinTargets := Str:Spec[][:]
+    lib.mixins.each |contribution|
+    {
+      target := contribution.base
+      if (target == null)
+        throw UnsupportedErr("Mixin contribution ${contribution.qname} has no target spec")
+
+      // +Spec declares metadata rather than application data. Known metadata
+      // is consumed by its mapping rule; metadata without a rule is omitted.
+      if (target.qname == "sys::Spec") return
+
+      mixinTargets.getOrAdd(target.qname) { Spec[,] }.add(contribution)
+    }
+    mixinTargets.each |contributions, targetQname|
+    {
+      target := ns.spec(targetQname, false)
+      if (target == null) target = contributions.first.base
+      if (target == null) throw UnsupportedErr("Mixin target not found: ${targetQname}")
+      mixinShape(target, contributions)
+    }
     lib.instances.each |x| { instance(x) }
     return this
   }
@@ -73,7 +94,7 @@ class RdfExporter : Exporter
     this.isSys = spec.lib.name == "sys"
     if (spec.isType) return cls(spec)
     if (spec.isGlobal) return global(spec)
-    throw Err(spec.name)
+    throw UnsupportedErr("RDF export target is neither a type nor a global: ${spec.qname}")
   }
 
 //////////////////////////////////////////////////////////////////////////
@@ -95,8 +116,12 @@ class RdfExporter : Exporter
     w("@prefix unit: <http://qudt.org/vocab/unit/> .").nl
     w("@prefix currency: <http://qudt.org/vocab/currency/> .").nl
     w("@prefix quantitykind: <http://qudt.org/vocab/quantitykind/> .").nl
-    lib.depends.each |x| { prefixDef(ns.lib(x.name)) }
-    prefixDef(lib)
+    // Effective shapes may contain slots contributed by any active namespace
+    // library, including mixins whose owner is not a direct dependency.
+    // Declare every active prefix so all emitted qnames are valid Turtle.
+    libs := ns.libs.dup.sort |a, b| { a.name <=> b.name }
+    libs.each |x| { prefixDef(x) }
+    if (!libs.any |x| { x.name == lib.name }) prefixDef(lib)
     nl
   }
 
@@ -172,9 +197,23 @@ class RdfExporter : Exporter
     // Classes with effective constraints are also SHACL node shapes.
     if (hasShape) w("  a sh:NodeShape ;").nl
 
-    // supertype
-    if (x.base != null) w("  rdfs:subClassOf ").qname(x.base.qname).w(" ;").nl
-    else  w("  rdfs:subClassOf rdfs:Resource ;").nl
+    // Intersections are subclasses of every member. Unions reverse that
+    // relationship below so each member is a subclass of the union.
+    if (x.isCompound && x.isAnd)
+    {
+      w("  rdfs:subClassOf ")
+      x.bases.each |base, i|
+      {
+        if (i > 0) w(", ")
+        qname(base.qname)
+      }
+      w(" ;").nl
+    }
+    else if (!(x.isCompound && x.isOr))
+    {
+      if (x.base != null) w("  rdfs:subClassOf ").qname(x.base.qname).w(" ;").nl
+      else  w("  rdfs:subClassOf rdfs:Resource ;").nl
+    }
 
     // label and comment properties
     labelAndDoc(x)
@@ -204,8 +243,51 @@ class RdfExporter : Exporter
     {
       slot(s)
     }
+    x.globalsOwn.each |g| { global(g) }
+
+    if (x.isCompound && x.isOr)
+    {
+      x.bases.each |member|
+      {
+        qname(member.qname).w(" rdfs:subClassOf ").qname(x.qname).w(" .").nl
+      }
+    }
 
     return this
+  }
+
+  ** Emit only this library's contribution to a dependency-owned target. The
+  ** dependency graph owns the target class and its original constraints;
+  ** this graph adds a SHACL shape with contributor-owned properties.
+  private Void mixinShape(Spec target, Spec[] contributions)
+  {
+    props   := Spec[,]
+    markers := Spec[,]
+    contributions.each |contribution|
+    {
+      contribution.slotsOwn.each |slot|
+      {
+        if (slot.isMarker) markers.add(slot)
+        else props.add(slot)
+      }
+    }
+
+    if (!props.isEmpty || markers.any |slot| { !slot.isMaybe })
+    {
+      qname(target.qname).nl
+      w("  a sh:NodeShape ;").nl
+      markers.each |slot| { hasMarker(slot) }
+      w("  sh:targetClass ").qname(target.qname).w(" ;").nl
+      props.each |slot| { propShape(slot) }
+      markers.each |slot| { if (!slot.isMaybe) markerShape(slot) }
+      w(".").nl
+    }
+
+    contributions.each |contribution|
+    {
+      contribution.slotsOwn.each |slot| { this.slot(slot) }
+      contribution.globalsOwn.each |globalSlot| { global(globalSlot) }
+    }
   }
 
   private Void hasMarker(Spec slot)
@@ -225,6 +307,27 @@ class RdfExporter : Exporter
 
   private Void propShape(Spec slot)
   {
+    type := slot.type
+    if (type.isThis || ((type.isRef || type.isMultiRef) && slot.of(false)?.isThis == true))
+      throw UnsupportedErr("RDF parent-relative This mapping not supported for ${slot.qname}")
+    if (type.isGrid)
+      throw UnsupportedErr("RDF Grid mapping not supported for ${slot.qname} of ${type.qname}")
+    if (type.qname == "sys::Collection")
+      throw UnsupportedErr("RDF Collection mapping not supported for ${slot.qname} of ${type.qname}")
+    if (type.isFunc)
+      throw UnsupportedErr("RDF Func mapping not supported for ${slot.qname} of ${type.qname}")
+    if (type.isInterface)
+      throw UnsupportedErr("RDF Interface mapping not supported for ${slot.qname} of ${type.qname}")
+    if (type.isComp)
+      throw UnsupportedErr("RDF runtime component mapping not supported for ${slot.qname} of ${type.qname}")
+
+    if (slot.isQuery)
+    {
+      required := slot.slotsOwn.list.find |Spec member->Bool| { !member.isMaybe }
+      if (required != null)
+        throw UnsupportedErr("RDF query body mapping not supported for required member ${required.qname}")
+    }
+
     // build constraints
     sh := Str:Obj[:]
     sh.ordered = true
@@ -232,13 +335,19 @@ class RdfExporter : Exporter
     hasMaxCount := true
 
     // value type
-    type := slot.type
     isQuantityValue := isQuantityValueSlot(slot)
     isLiteral := ((type.isScalar && !type.isRef) || type.qname == "sys::TimeZone") &&
                  !isQuantityValue && type.qname != "sys::Unit" &&
                  type.qname != "sys::UnitQuantity"
     datatype := isLiteral ? scalarDatatype(type) : null
-    if (type.qname == "sys::Unit")
+    if (slot.isQuery)
+    {
+      of := slot.of(false)
+      if (of != null) sh["class"] = qnameToUri(of.qname)
+      hasMinCount = false
+      hasMaxCount = false
+    }
+    else if (type.qname == "sys::Unit")
     {
       sh["class"] = "qudt:Unit"
     }
@@ -293,9 +402,13 @@ class RdfExporter : Exporter
 
     // write property shape
     w("  sh:property [").nl
-    w("    sh:path ").qname(slot.qname).w(" ;").nl
+    w("    sh:path ")
+    if (slot.isQuery) queryPath(slot)
+    else qname(slot.qname)
+    w(" ;").nl
     sh.each |v, n| { w("    sh:").w(n).w(" ").w(v).w(" ;").nl }
-    if (type.isEnum && type.qname != "sys::Unit" && type.qname != "sys::UnitQuantity")
+    if (type.isEnum && type.qname != "sys::Unit" &&
+        type.qname != "sys::UnitQuantity" && type.qname != "sys::TimeZone")
       enumConstraint(type)
     if (type.isChoice) choiceConstraint(slot)
     if (type.isList) listConstraint(slot)
@@ -307,6 +420,104 @@ class RdfExporter : Exporter
     if (isQuantityValue) quantityValueConstraint(slot)
     if (datatype != null) scalarConstraints(slot, datatype)
     w("  ] ;").nl
+  }
+
+  ** Write the computed SHACL property path for a query slot. Query metadata
+  ** is resolved in the library that owns the declaration, which matters for
+  ** slots contributed to another library's type by a mixin.
+  private Void queryPath(Spec query)
+  {
+    viaVal := query.meta["via"]
+    inverseVal := query.meta["inverse"]
+    if (viaVal != null && inverseVal != null)
+      throw UnsupportedErr("RDF query ${query.qname} cannot declare both via and inverse")
+
+    if (viaVal != null)
+    {
+      via := viaVal as Str
+        ?: throw UnsupportedErr("Invalid via metadata for ${query.qname}: ${viaVal.typeof}")
+      writeViaPath(query, via, false)
+      return
+    }
+
+    if (inverseVal != null)
+    {
+      inverse := inverseVal as Str
+        ?: throw UnsupportedErr("Invalid inverse metadata for ${query.qname}: ${inverseVal.typeof}")
+      inverseQname := resolveQueryName(query, inverse)
+      inverseQuery := resolveSpec(inverseQname)
+      if (inverseQuery != null && inverseQuery.isQuery)
+      {
+        inverseViaVal := inverseQuery.meta["via"]
+        inverseVia := inverseViaVal as Str
+        if (inverseViaVal != null && inverseVia == null)
+          throw UnsupportedErr("Invalid via metadata for ${inverseQuery.qname}: ${inverseViaVal.typeof}")
+        if (inverseVia == null)
+          throw UnsupportedErr("Inverse query ${query.qname} must reference a via query: ${inverseQname}")
+        writeViaPath(inverseQuery, inverseVia, true)
+      }
+      else
+      {
+        w("[ sh:inversePath ").qname(inverseQname).w(" ]")
+      }
+      return
+    }
+
+    // A plain query is still computed and has no cardinality, but its RDF
+    // predicate is the ordinary declared slot property.
+    qname(query.qname)
+  }
+
+  private Void writeViaPath(Spec query, Str source, Bool inverse)
+  {
+    if (source.isEmpty)
+      throw UnsupportedErr("Empty query path for ${query.qname}")
+
+    quantifier := ""
+    if (source.endsWith("+") || source.endsWith("*"))
+    {
+      quantifier = source[-1].toChar
+      source = source[0..-2]
+      if (source.isEmpty)
+        throw UnsupportedErr("Empty query path for ${query.qname}")
+    }
+
+    property := resolveQueryName(query, source)
+    if (!quantifier.isEmpty)
+      w(quantifier == "+" ? "[ sh:oneOrMorePath " : "[ sh:zeroOrMorePath ")
+    if (inverse) w("[ sh:inversePath ")
+    qname(property)
+    if (inverse) w(" ]")
+    if (!quantifier.isEmpty) w(" ]")
+  }
+
+  ** Resolve an unqualified path relative to the query declaration. A
+  ** Spec.slot path is relative to the declaration's library; a fully
+  ** qualified lib::Spec.slot path retains its explicit owner.
+  private Str resolveQueryName(Spec query, Str name)
+  {
+    if (name.contains("::")) return name
+    if (name.contains(".")) return "${query.lib.name}::${name}"
+    parent := query.parent
+      ?: throw UnsupportedErr("Query ${query.qname} has no declaring parent")
+    return "${parent.qname}.${name}"
+  }
+
+  ** Namespace lookup does not include a temporary library until installed,
+  ** so fall back to the currently exported library for its own query slots.
+  private Spec? resolveSpec(Str qname)
+  {
+    found := ns.spec(qname, false)
+    if (found != null) return found
+
+    lib := curLib
+    if (lib == null || !qname.startsWith("${lib.name}::")) return null
+    local := qname[qname.index("::") + 2..-1]
+    dot := local.index(".")
+    if (dot == null) return lib.spec(local, false)
+    parent := lib.spec(local[0..<dot], false)
+    if (parent == null) return null
+    return parent.slot(local[dot + 1..-1], false)
   }
 
   private Bool isQuantityValueSlot(Spec slot)
@@ -394,6 +605,8 @@ class RdfExporter : Exporter
     // The RDF specification constrains a choice slot to the member IRIs
     // visible in the active namespace, rather than to marker values.
     members := choiceMembers(slot)
+    if (members.isEmpty)
+      throw UnsupportedErr("RDF choice ${slot.qname} has no members in the active namespace")
     w("    sh:in (")
     members.each |member, i|
     {
@@ -498,7 +711,7 @@ class RdfExporter : Exporter
     maxSize := intMeta(slot, "maxSize")
     if (maxSize != null) w("    sh:maxLength ").w(maxSize).w(" ;").nl
 
-    pattern := scalarPattern(slot)
+    pattern := scalarPattern(slot, datatype)
     if (pattern != null)
       w("    sh:pattern ").literal(pattern).w(" ;").nl
 
@@ -511,7 +724,7 @@ class RdfExporter : Exporter
       if (val == null)
         throw UnsupportedErr("Invariant scalar slot ${slot.qname} is missing val metadata")
       w("    sh:hasValue ")
-      typedLiteral(val, datatype)
+      typedLiteral(val, slot.type, slot.qname)
       w(" ;").nl
     }
   }
@@ -537,8 +750,11 @@ class RdfExporter : Exporter
     throw UnsupportedErr("RDF scalar datatype not supported: ${type.qname}")
   }
 
-  private Str? scalarPattern(Spec slot)
+  private Str? scalarPattern(Spec slot, Str datatype)
   {
+    // Xeto's built-in numeric/date patterns describe source syntax and are
+    // not SHACL regex constraints on RDF typed literals.
+    if (datatype != "xsd:string") return null
     patternVal := slot.meta["pattern"]
     if (patternVal == null) return null
     pattern := patternVal as Str
@@ -625,16 +841,102 @@ class RdfExporter : Exporter
     return num.toInt
   }
 
-  private This typedLiteral(Obj val, Str datatype)
+  ** Convert only runtime values with a defined scalar mapping. This avoids
+  ** accepting an arbitrary object merely because its `toStr` happens to look
+  ** like a legal lexical form for the requested RDF datatype.
+  private This typedLiteral(Obj val, Spec type, Str context)
   {
-    literal(val.toStr).w("^^").w(datatype)
+    datatype := scalarDatatype(type)
+    lexical := scalarLexical(val, type, context)
+    return literal(lexical).w("^^").w(datatype)
+  }
+
+  private Str scalarLexical(Obj val, Spec type, Str context)
+  {
+    qname := type.qname
+    wrapped := val as Scalar
+    if (wrapped != null)
+    {
+      if (wrapped.qname != qname)
+        throw UnsupportedErr("Expected ${qname} for ${context}, not ${wrapped.qname}")
+      val = wrapped.val
+    }
+
+    if (qname == "sys::Str" || (type.isScalar && type.lib.name != "sys"))
+      return val as Str ?: throw UnsupportedErr("Expected Str for ${context}, not ${val.typeof}")
+
+    if (qname == "sys::Int")
+    {
+      if (val is Int) return val.toStr
+      num := val as Number
+      if (num == null || num.unit != null || num.isSpecial || !num.isInt)
+        throw UnsupportedErr("Expected integer value for ${context}, not ${val.typeof}")
+      return num.toInt.toStr
+    }
+
+    if (qname == "sys::Number")
+    {
+      if (val is Int) return val.toStr
+      num := val as Number
+      if (num == null || num.unit != null || num.isSpecial)
+        throw UnsupportedErr("Expected finite unitless Number for ${context}, not ${val.typeof}")
+      return num.isInt ? num.toInt.toStr : num.toFloat.toStr
+    }
+
+    if (qname == "sys::Bool")
+    {
+      if (val is Bool) return val.toStr
+      str := val as Str
+      if (str == "true" || str == "false") return str
+      throw UnsupportedErr("Expected Bool for ${context}, not ${val.typeof}")
+    }
+
+    if (qname == "sys::Date")
+    {
+      if (val is Date) return val.toStr
+      str := val as Str
+      if (str != null && Date.fromStr(str, false) != null) return str
+      throw UnsupportedErr("Expected Date for ${context}, not ${val.typeof}")
+    }
+
+    if (qname == "sys::Time")
+    {
+      if (val is Time) return val.toStr
+      str := val as Str
+      if (str != null && Time.fromStr(str, false) != null) return str
+      throw UnsupportedErr("Expected Time for ${context}, not ${val.typeof}")
+    }
+
+    if (qname == "sys::DateTime")
+    {
+      if (val is DateTime) return val.toStr
+      str := val as Str
+      if (str != null && DateTime.fromStr(str, false) != null) return str
+      throw UnsupportedErr("Expected DateTime for ${context}, not ${val.typeof}")
+    }
+
+    if (qname == "sys::Uri")
+    {
+      if (val is Uri) return val.toStr
+      str := val as Str
+      if (str != null && Uri.fromStr(str, false) != null) return str
+      throw UnsupportedErr("Expected Uri for ${context}, not ${val.typeof}")
+    }
+
+    if (qname == "sys::TimeZone")
+    {
+      if (val is TimeZone) return val.toStr
+      str := val as Str
+      if (str != null && TimeZone.fromStr(str, false) != null) return str
+      throw UnsupportedErr("Expected TimeZone for ${context}, not ${val.typeof}")
+    }
+
+    throw UnsupportedErr("RDF scalar value mapping not supported for ${context} of ${qname}")
   }
 
   private This global(Spec x)
   {
-    // don't generate globals, just class properties
-    // prop(x)
-    return this
+    return prop(x)
   }
 
   private This slot(Spec x)
@@ -661,24 +963,28 @@ class RdfExporter : Exporter
   {
     qname(x.qname).nl
     w("  a rdf:Property ;").nl
-    if (!x.base.isType)
-      w("  rdfs:subClassOf ").qname(x.base.qname).w("; ").nl
+    if (x.base != null && !x.base.isType)
+      w("  rdfs:subPropertyOf ").qname(x.base.qname).w(" ;").nl
     labelAndDoc(x)
-    type := globalType(x)
-    // if (type != null) w("  rdfs:range ").w(type).w(" ;").nl
     w(".").nl
     return this
   }
 
-  private Str? globalType(Spec x)
+  ** Sealed is a schema validity rule rather than an RDF statement. Xeto's
+  ** compiler normally prevents this state, but an exporter must still fail
+  ** closed if handed a namespace assembled by another implementation.
+  private Void validateSealedNamespace(Lib lib)
   {
-    type := x.type
-    if (type.qname == "sys::Str") return "xsd:string"
-    if (type.qname == "sys::Int") return "xsd:integer"
-    if (type.isEnum) return qnameToUri(type.qname)
-    if (type.isChoice) return qnameToUri(type.qname)
-    if (type.isRef || type.isMultiRef) return x.of(false)?.qname ?: "sys:Entity"
-    return null
+    candidates := Str:Spec[:]
+    ns.eachType |candidate| { candidates[candidate.qname] = candidate }
+    lib.types.each |candidate| { candidates[candidate.qname] = candidate }
+    candidates.each |candidate|
+    {
+      base := candidate.base
+      if (base == null) return
+      if (base.lib.name != candidate.lib.name && base.meta.has("sealed"))
+        throw UnsupportedErr("External subtype ${candidate.qname} extends sealed spec ${base.qname}")
+    }
   }
 
   private This labelAndDoc(Spec x)
@@ -697,10 +1003,6 @@ class RdfExporter : Exporter
   override This instance(Dict instance)
   {
     id := instance.id
-
-    // TODO - just hide op/filetype instances for now
-    if (id.toStr.startsWith("ph::op:")) return this
-    if (id.toStr.startsWith("ph::filetype:")) return this
 
     spec := instanceSpec(instance)
     this.id(id).nl
@@ -773,6 +1075,14 @@ class RdfExporter : Exporter
       return
     }
 
+    if (type.qname == "sys::TimeZone")
+    {
+      w(indent).qname(property).w(" ")
+      typedLiteral(val, type, property)
+      w(" ;").nl
+      return
+    }
+
     if (type.isEnum)
     {
       if (type.qname == "sys::Unit")
@@ -783,7 +1093,11 @@ class RdfExporter : Exporter
       }
       if (type.qname == "sys::UnitQuantity")
         throw UnsupportedErr("RDF mapping not implemented for ${type.qname}")
-      key := val.toStr
+      scalar := val as Scalar
+        ?: throw UnsupportedErr("Expected ${type.qname} enum value for ${property}, not ${val.typeof}")
+      if (scalar.qname != type.qname)
+        throw UnsupportedErr("Expected ${type.qname} enum value for ${property}, not ${scalar.qname}")
+      key := scalar.val
       if (type.enum.spec(key, false) == null)
         throw UnsupportedErr("Invalid ${type.qname} value: ${key}")
       w(indent).qname(property).w(" ").literal(key).w("^^xsd:string ;").nl
@@ -812,8 +1126,17 @@ class RdfExporter : Exporter
         return
       }
       w(indent).qname(property).w(" ")
-      typedLiteral(val, scalarDatatype(type))
+      typedLiteral(val, type, property)
       w(" ;").nl
+      return
+    }
+
+    if (type.qname == "sys::Obj")
+    {
+      actual := ns.specOf(val, false)
+      if (actual == null || actual.qname == "sys::Obj")
+        throw UnsupportedErr("RDF Obj value type is ambiguous for ${property}: ${val.typeof}")
+      instanceMember(property, actual, val, indent)
       return
     }
 
@@ -914,7 +1237,7 @@ class RdfExporter : Exporter
       num := item as Number
       if (num != null && num.unit != null)
         throw UnsupportedErr("RDF quantity list item mapping not implemented for ${property}")
-      typedLiteral(item, scalarDatatype(type))
+      typedLiteral(item, type, property)
       return
     }
 
@@ -1006,13 +1329,45 @@ class RdfExporter : Exporter
   ** Output Xeto lib::name qualified name
   private This qname(Str qname)
   {
-    w(qnameToUri(qname))
+    validateQName(qname, "RDF name")
+    return w(qnameToUri(qname))
   }
 
   ** Output Xeto lib::name qualified name
   private This id(Ref id)
   {
-    w(qnameToUri(id.toStr))
+    qname := id.toStr
+    sep := qname.index("::")
+    if (sep == null || sep == 0 || sep + 2 >= qname.size || qname.index("::", sep + 2) != null)
+      throw UnsupportedErr("RDF instance id or reference is not library-qualified: ${qname}")
+
+    libName := qname[0..<sep]
+    local := qname[sep + 2..-1]
+    lib := curLib?.name == libName ? curLib : ns.lib(libName, false)
+    if (lib == null)
+      throw UnsupportedErr("RDF instance id or reference uses unknown library ${libName}: ${qname}")
+
+    // Keep ordinary Xeto qnames readable. Ref ids may also contain schemes
+    // such as `op:name` and `filetype:json`; those are legal RDF fragments
+    // but not legal prefixed names, so write their full versioned IRI.
+    if (!local.contains(":") && !local.contains(" ") && !local.contains("\t") &&
+        !local.contains("\r") && !local.contains("\n") && !local.contains("<") &&
+        !local.contains(">") && !local.contains("\"") && !local.contains("\\"))
+      return w(libName).w(":").w(local)
+
+    encoded := Uri.encodeToken(local, Uri.sectionFrag)
+    return w("<").w(libUri(lib)).w("#").w(encoded).w(">")
+  }
+
+  private Void validateQName(Str qname, Str kind)
+  {
+    sep := qname.index("::")
+    invalid := sep == null || sep == 0 || sep + 2 >= qname.size ||
+      qname.index("::", sep + 2) != null || qname[sep + 2..-1].contains(":") ||
+      qname.contains(" ") || qname.contains("\t") || qname.contains("\r") ||
+      qname.contains("\n") || qname.contains("<") || qname.contains(">") ||
+      qname.contains("\"") || qname.contains("\\")
+    if (invalid) throw UnsupportedErr("${kind} is not QName-compatible: ${qname}")
   }
 
   ** Quoted string literal

--- a/src/core/xetom/fan/export/RdfExporter.fan
+++ b/src/core/xetom/fan/export/RdfExporter.fan
@@ -633,7 +633,10 @@ class RdfExporter : Exporter
 
   private Spec[] choiceMembers(Spec slot)
   {
-    choice := ns.choice(slot)
+    // The declared slot type defines the selected branch. For an intermediate
+    // Choice this includes the marker-bearing type itself and its descendants,
+    // but excludes sibling branches under the root Choice.
+    choiceType := slot.type
 
     // Namespace types cover installed dependency libraries. curLib is merged
     // explicitly because temporary or currently-exported libraries are not
@@ -647,7 +650,7 @@ class RdfExporter : Exporter
     candidates.each |candidate|
     {
       if (!candidate.isChoice) return
-      if (!candidate.isa(choice.type)) return
+      if (!candidate.isa(choiceType)) return
       if (!candidate.slots.list.any |Spec memberSlot->Bool| { memberSlot.isMarker }) return
       members.add(candidate)
     }
@@ -727,9 +730,10 @@ class RdfExporter : Exporter
     maxSize := intMeta(slot, "maxSize")
     if (maxSize != null) w("    sh:maxLength ").w(maxSize).w(" ;").nl
 
-    pattern := scalarPattern(slot, datatype)
-    if (pattern != null)
+    scalarPatterns(slot, datatype).each |pattern|
+    {
       w("    sh:pattern ").literal(pattern).w(" ;").nl
+    }
 
     if (meta.has("nonEmpty"))
       w("    sh:pattern ").literal("\\S").w(" ;").nl
@@ -766,13 +770,35 @@ class RdfExporter : Exporter
     throw UnsupportedErr("RDF scalar datatype not supported: ${type.qname}")
   }
 
-  private Str? scalarPattern(Spec slot, Str datatype)
+  ** Return every string pattern contributed by the custom scalar hierarchy,
+  ** followed by any slot-level refinement. Each pattern is a separate SHACL
+  ** constraint, so a value must satisfy the complete inherited contract.
+  private Str[] scalarPatterns(Spec slot, Str datatype)
   {
     // Xeto's built-in numeric/date patterns describe source syntax and are
     // not SHACL regex constraints on RDF typed literals.
-    if (datatype != "xsd:string") return null
+    if (datatype != "xsd:string") return Str[,]
+
+    patterns := Str[,]
+    added := Str:Bool[:]
+    chain := Spec[,]
+    seen := Str:Bool[:]
+    Spec? cur := slot.type
+    while (cur != null && cur.isScalar && cur.lib.name != "sys")
+    {
+      if (seen.containsKey(cur.qname))
+        throw UnsupportedErr("Cyclic Xeto type inheritance while resolving ${slot.type.qname}: ${cur.qname}")
+      seen[cur.qname] = true
+      chain.add(cur)
+      cur = cur.base
+    }
+    chain.reverse.each |type|
+    {
+      addScalarPattern(patterns, added, type.qname, type.meta["pattern"])
+    }
+
     patternVal := slot.meta["pattern"]
-    if (patternVal == null) return null
+    if (patternVal == null) return patterns
     pattern := patternVal as Str
       ?: throw UnsupportedErr("Invalid pattern metadata for ${slot.qname}: ${patternVal.typeof}")
 
@@ -786,9 +812,24 @@ class RdfExporter : Exporter
       typePattern := typePatternVal as Str
       if (typePatternVal != null && typePattern == null)
         throw UnsupportedErr("Invalid pattern metadata for ${type.qname}: ${typePatternVal.typeof}")
-      if (pattern == typePattern) return null
+      if (pattern == typePattern) return patterns
     }
-    return pattern
+    if (!added.containsKey(pattern))
+    {
+      added[pattern] = true
+      patterns.add(pattern)
+    }
+    return patterns
+  }
+
+  private Void addScalarPattern(Str[] patterns, Str:Bool added, Str owner, Obj? val)
+  {
+    if (val == null) return
+    pattern := val as Str
+      ?: throw UnsupportedErr("Invalid pattern metadata for ${owner}: ${val.typeof}")
+    if (added.containsKey(pattern)) return
+    added[pattern] = true
+    patterns.add(pattern)
   }
 
   private Bool isBuiltInScalar(Str qname)

--- a/src/core/xetom/fan/export/RdfExporter.fan
+++ b/src/core/xetom/fan/export/RdfExporter.fan
@@ -51,6 +51,7 @@ class RdfExporter : Exporter
   override This lib(Lib lib)
   {
     this.curLib = lib
+    this.instanceMemberSpecs.clear
     this.isSys = lib.name == "sys"
     validateNamespaceVersions(lib)
     prefixDefs(lib)
@@ -1142,7 +1143,7 @@ class RdfExporter : Exporter
       if (choiceMarkers.containsKey(member.name)) return
 
       val := member.val
-      slot := member.spec
+      slot := instanceMemberSpec(spec, member)
       // Global-slot reflection may expose the declaration without carrying the
       // value already materialized on the completed instance dictionary.
       if (val == null && instance.has(member.name)) val = instance[member.name]
@@ -1168,7 +1169,7 @@ class RdfExporter : Exporter
 
   private Str[] instanceProperties(Spec parent, ReflectMember member)
   {
-    spec := member.spec
+    spec := instanceMemberSpec(parent, member)
     properties := Str:Bool[:]
     properties[instanceProperty(parent, member)] = true
     while (spec.isSlot && spec.base != null && (spec.base.isSlot || spec.base.isGlobal))
@@ -1181,8 +1182,52 @@ class RdfExporter : Exporter
 
   private Str instanceProperty(Spec parent, ReflectMember member)
   {
-    spec := member.spec
+    spec := instanceMemberSpec(parent, member)
     return spec.isSlot ? spec.qname : "${parent.qname}.${member.name}"
+  }
+
+  ** Reflection exposes a mixin slot as the target library's materialized
+  ** effective slot. Recover this exporting library's declaration so instance
+  ** properties retain the contributor qname and its original type contract.
+  private Spec instanceMemberSpec(Spec parent, ReflectMember member)
+  {
+    cacheKey := "${parent.qname}.${member.name}"
+    cached := instanceMemberSpecs[cacheKey]
+    if (cached != null) return cached
+
+    // Include installed namespace libraries for direct instance() export, then
+    // overlay curLib because a temporary library is not necessarily installed.
+    libs := Str:Lib[:]
+    ns.libs.each |lib| { libs[lib.name] = lib }
+    if (curLib != null) libs[curLib.name] = curLib
+
+    matches := Str:Spec[:]
+    libs.each |lib|
+    {
+      lib.mixins.each |contribution|
+      {
+        target := contribution.base
+        if (target == null)
+          throw UnsupportedErr("Mixin contribution ${contribution.qname} has no target spec")
+        if (!parent.isa(target)) return
+
+        slot := contribution.slotOwn(member.name, false)
+        if (slot == null) return
+        previous := matches[slot.qname]
+        if (previous != null && previous !== slot)
+          throw UnsupportedErr("Ambiguous mixin property for ${parent.qname}.${member.name}: ${slot.qname}")
+        matches[slot.qname] = slot
+      }
+    }
+
+    if (matches.size > 1)
+    {
+      names := matches.keys.sort.join(", ")
+      throw UnsupportedErr("Ambiguous mixin property for ${parent.qname}.${member.name}: ${names}")
+    }
+    resolved := matches.vals.first ?: member.spec
+    instanceMemberSpecs[cacheKey] = resolved
+    return resolved
   }
 
   private Void instanceMember(Str property, Spec type, Obj val, Str indent)
@@ -1429,6 +1474,7 @@ class RdfExporter : Exporter
 //////////////////////////////////////////////////////////////////////////
 
   private Lib? curLib
+  private Str:Spec instanceMemberSpecs := [:]
   private Bool instancesOnly
   private Bool schemaOnly
   private RdfQudtMappings? qudtRef

--- a/src/core/xetom/fan/export/RdfExporter.fan
+++ b/src/core/xetom/fan/export/RdfExporter.fan
@@ -197,8 +197,9 @@ class RdfExporter : Exporter
       if (s.isMarker) markers.add(s)
       else props.add(s)
     }
+    isAbstract := x.meta.has("abstract")
     hasShape := !x.isEnum &&
-                ((x.isCompound && x.isOr) || !props.isEmpty || markers.any |s| { !s.isMaybe })
+                (isAbstract || (x.isCompound && x.isOr) || !props.isEmpty || markers.any |s| { !s.isMaybe })
 
     qname(x.qname).nl
 
@@ -249,6 +250,17 @@ class RdfExporter : Exporter
         w("  sh:or (").nl
         x.bases.each |member| { w("    [ sh:class ").qname(member.qname).w(" ]").nl }
         w("  ) ;").nl
+      }
+      if (isAbstract)
+      {
+        // Concrete descendants remain valid; reject only an instance whose
+        // rdf:type directly names this abstract spec.
+        w("  sh:not [").nl
+        w("    sh:property [").nl
+        w("      sh:path rdf:type ;").nl
+        w("      sh:hasValue ").qname(x.qname).nl
+        w("    ]").nl
+        w("  ] ;").nl
       }
       props.each |s| { propShape(s) }
       markers.each |s| { if (!s.isMaybe) markerShape(s) }
@@ -808,8 +820,9 @@ class RdfExporter : Exporter
       case "sys::TimeZone": return "xsd:string"
     }
 
-    // User-defined Scalar subtypes have string lexical values unless this
-    // profile assigns their qname a more specific datatype above.
+    // sys is a closed runtime vocabulary, so an unlisted sys scalar is
+    // unsupported. A declared non-sys Scalar is the profile's custom string
+    // datatype extension unless a more specific mapping appears above.
     if (type.isScalar && type.lib.name != "sys") return "xsd:string"
     throw UnsupportedErr("RDF scalar datatype not supported: ${type.qname}")
   }
@@ -971,8 +984,18 @@ class RdfExporter : Exporter
       val = wrapped.val
     }
 
-    if (qname == "sys::Str" || (type.isScalar && type.lib.name != "sys"))
+    if (qname == "sys::Str")
       return val as Str ?: throw UnsupportedErr("Expected Str for ${context}, not ${val.typeof}")
+
+    if (type.isScalar && type.lib.name != "sys")
+    {
+      str := val as Str
+      if (str != null) return str
+      binding := type.binding
+      if (binding.isScalar && val.typeof.fits(binding.type))
+        return binding.encodeScalar(val)
+      throw UnsupportedErr("Expected ${binding.type} for ${context}, not ${val.typeof}")
+    }
 
     if (qname == "sys::Int")
     {
@@ -1074,6 +1097,8 @@ class RdfExporter : Exporter
   {
     qname(x.qname).nl
     w("  a sys:Marker ;").nl
+    if (x.base != null && !x.base.isType)
+      w("  rdfs:subPropertyOf ").qname(x.base.qname).w(" ;").nl
     labelAndDoc(x)
     w(".").nl
     return this
@@ -1135,6 +1160,9 @@ class RdfExporter : Exporter
 
   private Void instanceMembers(Dict instance, Spec spec, Str indent)
   {
+    storedNames := Str:Bool[:]
+    instance.each |val, name| { storedNames[name] = true }
+
     choiceMarkers := Str:Bool[:]
     spec.slots.each |slot|
     {
@@ -1155,24 +1183,19 @@ class RdfExporter : Exporter
       if (member.name == "id" || member.name == "spec" || member.isChoice) return
       if (choiceMarkers.containsKey(member.name)) return
 
-      val := member.val
       slot := instanceMemberSpec(spec, member)
-      // Global-slot reflection may expose the declaration without carrying the
-      // value already materialized on the completed instance dictionary.
-      if (val == null && instance.has(member.name)) val = instance[member.name]
-      if (val == null && !slot.isMaybe &&
-          (slot.type.isScalar || slot.type.isEnum) && slot.meta.has("val"))
-        val = slot.meta["val"]
+      val := storedNames.containsKey(member.name) ? member.val : null
       if (val == null) return
 
       // The runtime Ref type uses @x as an internal construction placeholder.
       // Only export it when the instance actually authored that member.
       ref := val as Ref
-      if (ref != null && ref.id == "x" && !instance.has(member.name)) return
+      if (ref != null && ref.id == "x" && !storedNames.containsKey(member.name)) return
 
-      // Parameterized list metadata such as `of` and size constraints lives
-      // on the slot spec, not the shared sys::List type.
-      type := slot.isSlot && slot.type.isList ? slot : (slot.isSlot ? slot.type : slot)
+      // Slots and globals both wrap their value type. Parameterized list
+      // metadata such as `of` and size constraints remains on that wrapper.
+      isMember := slot.isSlot || slot.isGlobal
+      type := isMember && slot.type.isList ? slot : (isMember ? slot.type : slot)
       instanceProperties(spec, member).each |property|
       {
         instanceMember(property, type, val, indent)

--- a/src/core/xetom/fan/export/RdfExporter.fan
+++ b/src/core/xetom/fan/export/RdfExporter.fan
@@ -728,11 +728,23 @@ class RdfExporter : Exporter
   {
     meta := slot.meta
 
-    minVal := numericMeta(slot, "minVal")
-    if (minVal != null) w("    sh:minInclusive ").w(minVal).w(" ;").nl
+    minVal := numericMeta(slot, "minVal", datatype)
+    if (minVal != null)
+    {
+      w("    sh:minInclusive ")
+      if (datatype == "xsd:double") literal(minVal).w("^^xsd:double")
+      else w(minVal)
+      w(" ;").nl
+    }
 
-    maxVal := numericMeta(slot, "maxVal")
-    if (maxVal != null) w("    sh:maxInclusive ").w(maxVal).w(" ;").nl
+    maxVal := numericMeta(slot, "maxVal", datatype)
+    if (maxVal != null)
+    {
+      w("    sh:maxInclusive ")
+      if (datatype == "xsd:double") literal(maxVal).w("^^xsd:double")
+      else w(maxVal)
+      w(" ;").nl
+    }
 
     minSize := intMeta(slot, "minSize")
     if (minSize != null) w("    sh:minLength ").w(minSize).w(" ;").nl
@@ -765,6 +777,7 @@ class RdfExporter : Exporter
     {
       case "sys::Str":      return "xsd:string"
       case "sys::Number":   return "xsd:decimal"
+      case "sys::Float":    return "xsd:double"
       case "sys::Int":      return "xsd:integer"
       case "sys::Bool":     return "xsd:boolean"
       case "sys::Date":     return "xsd:date"
@@ -845,17 +858,36 @@ class RdfExporter : Exporter
   private Bool isBuiltInScalar(Str qname)
   {
     qname == "sys::Str"     || qname == "sys::Number" ||
-    qname == "sys::Int"     || qname == "sys::Bool"   ||
+    qname == "sys::Float"   || qname == "sys::Int"    ||
+    qname == "sys::Bool"    ||
     qname == "sys::Date"    || qname == "sys::Time"   ||
     qname == "sys::DateTime"|| qname == "sys::Uri"    ||
     qname == "sys::TimeZone"
   }
 
-  private Str? numericMeta(Spec slot, Str name)
+  private Str? numericMeta(Spec slot, Str name, Str datatype)
   {
     val := slot.meta[name]
     if (val == null) return null
     context := "${slot.qname}.${name}"
+    if (datatype == "xsd:double")
+    {
+      if (val is Int) return doubleLexical(val.toStr, context)
+      if (val is Float)
+      {
+        lexical := doubleLexical(val.toStr, context)
+        if (lexical == "NaN")
+          throw UnsupportedErr("Invalid numeric metadata for ${context}: NaN is not an ordered bound")
+        return lexical
+      }
+      num := val as Number
+      if (num == null || num.unit != null)
+        throw UnsupportedErr("Invalid numeric metadata for ${context}: ${val.typeof}")
+      lexical := doubleLexical(num.toStr, context)
+      if (lexical == "NaN")
+        throw UnsupportedErr("Invalid numeric metadata for ${context}: NaN is not an ordered bound")
+      return lexical
+    }
     if (val is Int) return decimalLexical(val.toStr, context)
     if (val is Float)
     {
@@ -954,6 +986,17 @@ class RdfExporter : Exporter
         throw UnsupportedErr("Expected finite unitless Number for ${context}, not ${val.typeof}")
       source := num.isInt ? num.toInt.toStr : num.toFloat.toStr
       return decimalLexical(source, context)
+    }
+
+    if (qname == "sys::Float")
+    {
+      if (val is Int) return doubleLexical(val.toStr, context)
+      float := val as Float
+      if (float != null) return doubleLexical(float.toStr, context)
+      num := val as Number
+      if (num == null || num.unit != null)
+        throw UnsupportedErr("Expected unitless Float for ${context}, not ${val.typeof}")
+      return doubleLexical(num.toStr, context)
     }
 
     if (qname == "sys::Bool")
@@ -1589,6 +1632,58 @@ class RdfExporter : Exporter
     buf := StrBuf(count)
     count.times { buf.addChar('0') }
     return buf.toStr
+  }
+
+  ** Validate one Xeto Float and use a stable xsd:double lexical form.
+  private Str doubleLexical(Str source, Str context)
+  {
+    if (source == "NaN" || source == "INF" || source == "-INF") return source
+    if (source.isEmpty)
+      throw UnsupportedErr("Invalid RDF double for ${context}: ${source}")
+
+    negative := source[0] == '-'
+    hasSign := negative || source[0] == '+'
+    unsigned := hasSign ? (source.size == 1 ? "" : source[1..-1]) : source
+    if (unsigned.isEmpty)
+      throw UnsupportedErr("Invalid RDF double for ${context}: ${source}")
+
+    lowerExp := unsigned.index("e")
+    upperExp := unsigned.index("E")
+    if (lowerExp != null && upperExp != null)
+      throw UnsupportedErr("Invalid RDF double for ${context}: ${source}")
+    expIndex := lowerExp ?: upperExp
+    exponent := 0
+    mantissa := unsigned
+    if (expIndex != null)
+    {
+      mantissa = expIndex == 0 ? "" : unsigned[0..<expIndex]
+      exponentText := expIndex == unsigned.size-1 ? "" : unsigned[expIndex+1..-1]
+      exponentVal := exponentText.toInt(10, false)
+      if (exponentVal == null)
+        throw UnsupportedErr("Invalid RDF double for ${context}: ${source}")
+      exponent = exponentVal
+    }
+
+    dot := mantissa.index(".")
+    if (dot != null && mantissa.index(".", dot+1) != null)
+      throw UnsupportedErr("Invalid RDF double for ${context}: ${source}")
+    integer := dot == null ? mantissa : (dot == 0 ? "" : mantissa[0..<dot])
+    fraction := dot == null || dot == mantissa.size-1 ? "" : mantissa[dot+1..-1]
+    if (integer.isEmpty && fraction.isEmpty)
+      throw UnsupportedErr("Invalid RDF double for ${context}: ${source}")
+    if (!(integer + fraction).all |char| { char.isDigit })
+      throw UnsupportedErr("Invalid RDF double for ${context}: ${source}")
+
+    first := 0
+    while (first < integer.size && integer[first] == '0') first++
+    integer = first == integer.size ? "0" : integer[first..-1]
+    last := fraction.size - 1
+    while (last >= 0 && fraction[last] == '0') last--
+    fraction = last < 0 ? "" : fraction[0..last]
+
+    sign := negative ? "-" : ""
+    normalized := fraction.isEmpty ? "${sign}${integer}" : "${sign}${integer}.${fraction}"
+    return exponent == 0 ? normalized : "${normalized}E${exponent}"
   }
 
   ** Quoted string literal

--- a/src/core/xetom/fan/export/RdfQudtMappings.fan
+++ b/src/core/xetom/fan/export/RdfQudtMappings.fan
@@ -1,0 +1,130 @@
+//
+// Copyright (c) 2026, SkyFoundry LLC
+// Licensed under the Academic Free License version 3.0
+//
+// History:
+//   18 Aug 2026  Creation
+//
+
+using xeto
+
+**
+** Strict access to the canonical Xeto-to-QUDT resources packaged by sys.rdf.
+**
+@NoDoc @Js
+const class RdfQudtMappings
+{
+  ** Load and validate the canonical resources from the active namespace.
+  static RdfQudtMappings load(Namespace ns)
+  {
+    lib := ns.lib("sys.rdf", false)
+      ?: throw IOErr("RDF QUDT mappings require the sys.rdf library")
+    unitsFile := lib.files.get(`/qudt-units.props`, false)
+      ?: throw IOErr("sys.rdf is missing /qudt-units.props")
+    quantitiesFile := lib.files.get(`/qudt-quantities.props`, false)
+      ?: throw IOErr("sys.rdf is missing /qudt-quantities.props")
+    return make(unitsFile.readAllStr, quantitiesFile.readAllStr)
+  }
+
+  ** Parse source strings. Public for focused validation tests.
+  new make(Str unitsSource, Str quantitiesSource)
+  {
+    unitRows := parseProps("qudt-units.props", unitsSource)
+    if (unitRows.isEmpty) throw IOErr("qudt-units.props: mapping resource is empty")
+    unitRows.each |Str target, Str name|
+    {
+      unit := Unit.fromStr(name, false)
+      if (unit == null || unit.name != name)
+        throw IOErr("qudt-units.props: unknown canonical Xeto unit '$name'")
+      validateTarget("qudt-units.props", name, target)
+    }
+
+    quantityRows := parseProps("qudt-quantities.props", quantitiesSource)
+    if (quantityRows.isEmpty) throw IOErr("qudt-quantities.props: mapping resource is empty")
+    quantities := Str:Str[][:]
+    quantityRows.each |Str targets, Str name|
+    {
+      quantity := UnitQuantity.fromStr(name, false)
+      if (quantity == null || quantity.name != name)
+        throw IOErr("qudt-quantities.props: unknown Xeto quantity '$name'")
+      Str[] parsed := targets.split(',').map |Str target->Str| { target.trim }
+      if (parsed.isEmpty || parsed.any { it.isEmpty })
+        throw IOErr("qudt-quantities.props: empty QUDT target for '$name'")
+      seen := Str:Bool[:]
+      parsed.each |target|
+      {
+        validateTarget("qudt-quantities.props", name, target)
+        if (seen[target] == true)
+          throw IOErr("qudt-quantities.props: duplicate QUDT target '$target' for '$name'")
+        seen[target] = true
+      }
+      quantities[name] = parsed.toImmutable
+    }
+
+    this.units = unitRows.toImmutable
+    this.quantities = quantities.toImmutable
+  }
+
+  ** Map a runtime unit, resolved from any accepted name or symbol, to QUDT.
+  Str unit(Unit unit)
+  {
+    target := units[unit.name]
+      ?: throw UnsupportedErr("No reviewed QUDT mapping for Xeto unit '${unit.name}'")
+    quantity := UnitQuantity.unitToQuantity[unit]
+      ?: throw UnsupportedErr("Xeto unit '${unit.name}' has no runtime quantity")
+    prefix := quantity == UnitQuantity.currency ? "currency" : "unit"
+    return "${prefix}:${target}"
+  }
+
+  ** Map one Xeto quantity to all accepted QUDT quantity-kind alternatives.
+  Str[] quantity(UnitQuantity quantity)
+  {
+    quantities[quantity.name]
+      ?: throw UnsupportedErr("No reviewed QUDT mapping for Xeto quantity '${quantity.name}'")
+  }
+
+  ** Number of mapped canonical units.
+  Int unitCount() { units.size }
+
+  ** Number of mapped Xeto quantities.
+  Int quantityCount() { quantities.size }
+
+  private static Str:Str parseProps(Str file, Str source)
+  {
+    rows := Str:Str[:]
+    lines := Str:Int[:]
+    source.splitLines.each |sourceLine, index|
+    {
+      lineNum := index + 1
+      row := sourceLine.trim
+      if (row.isEmpty || row.startsWith("//") || row.startsWith("#")) return
+
+      equals := row.index("=")
+      if (equals == null || equals == 0 || equals == row.size-1 ||
+          row.index("=", equals + 1) != null)
+        throw IOErr("${file}:${lineNum}: expected one non-empty name=value row")
+
+      name := row[0..<equals].trim
+      value := row[equals+1..-1].trim
+      if (name.isEmpty || value.isEmpty)
+        throw IOErr("${file}:${lineNum}: expected one non-empty name=value row")
+      firstLine := lines[name]
+      if (firstLine != null)
+        throw IOErr("${file}:${lineNum}: duplicate mapping '$name'; first declared on line $firstLine")
+      rows[name] = value
+      lines[name] = lineNum
+    }
+    return rows
+  }
+
+  private static Void validateTarget(Str file, Str name, Str target)
+  {
+    if (!qudtLocalName.matches(target))
+      throw IOErr("${file}: invalid QUDT target '$target' for '$name'")
+  }
+
+  private static const Regex qudtLocalName := Regex<|[A-Za-z_][A-Za-z0-9._-]*|>
+
+  private const Str:Str units
+  private const Str:Str[] quantities
+}

--- a/src/test/testXeto/fan/ExportTest.fan
+++ b/src/test/testXeto/fan/ExportTest.fan
@@ -17,6 +17,27 @@ using haystack
 @Js
 class ExportTest : AbstractXetoTest
 {
+  Void testGlobalIdentityJson()
+  {
+    ns := createNamespace(["sys"])
+    lib := ns.compileTempLib(
+      Str<|Person : Dict { *height: Number <minVal:0, maxVal:300, maybe> }
+             TallPerson : Person { height: Int <minVal:100> }|>)
+    buf := Buf()
+    JsonExporter(ns, buf.out, Etc.dict1("effective", m)).start.lib(lib).end
+    doc := (Str:Obj?)JsonInStream(buf.flip.in).readJson
+    exported := (Str:Obj?)doc.getChecked(lib.name)
+    person := (Str:Obj?)exported.getChecked("Person")
+    globals := (Str:Obj?)person.getChecked("globals")
+    height := (Str:Obj?)globals.getChecked("height")
+    verifyEq(height["global"], "\u2713")
+
+    tall := (Str:Obj?)exported.getChecked("TallPerson")
+    slots := (Str:Obj?)tall.getChecked("slots")
+    narrowed := (Str:Obj?)slots.getChecked("height")
+    verifyEq(narrowed["base"], "${lib.name}::Person.height")
+  }
+
   Void test()
   {
     ns := createNamespace(["hx.test.xeto"])
@@ -261,4 +282,3 @@ class ExportTest : AbstractXetoTest
     return e.toGrid
   }
 }
-

--- a/src/test/testXeto/fan/RdfExportTest.fan
+++ b/src/test/testXeto/fan/RdfExportTest.fan
@@ -318,6 +318,12 @@ class RdfExportTest : AbstractXetoTest
     buf := Buf()
     RdfExporter(ns, buf.out, Etc.dict0).start.instance(colonId).end
     verify(buf.flip.readAllStr.contains("#op:bad>"))
+
+    unknownLibId := Etc.makeDict(["id":Ref("missing.lib::bad"), "spec":Ref("sys::Dict")])
+    verifyErrMsg(UnsupportedErr#, "Concrete Xeto library version unavailable for missing.lib")
+    {
+      RdfExporter(ns, Buf().out, Etc.dict0).start.instance(unknownLibId).end
+    }
   }
 
   Void testStructuredValueShapes()

--- a/src/test/testXeto/fan/RdfExportTest.fan
+++ b/src/test/testXeto/fan/RdfExportTest.fan
@@ -40,6 +40,24 @@ class RdfExportTest : AbstractXetoTest
     verifyEq(countMatches(rdf, "temp:Person.dis\n  a rdf:Property ;"), 1)
   }
 
+  Void testAbstractSpecRejectsDirectType()
+  {
+    rdf := export(
+      Str<|AbstractThing : Dict <abstract> {
+               dis: Str
+             }
+
+             ConcreteThing : AbstractThing|>)
+
+    abstractRdf := rdf[rdf.index("temp:AbstractThing\n")..<rdf.index("temp:ConcreteThing\n")]
+    verify(abstractRdf.contains("a sh:NodeShape ;"), abstractRdf)
+    verify(abstractRdf.contains("sh:path rdf:type ;"), abstractRdf)
+    verify(abstractRdf.contains("sh:hasValue temp:AbstractThing"), abstractRdf)
+
+    concrete := rdf[rdf.index("temp:ConcreteThing\n")..-1]
+    verifyFalse(concrete.contains("sh:hasValue temp:ConcreteThing"), concrete)
+  }
+
   Void testScalarConstraints()
   {
     rdf := export(
@@ -154,6 +172,7 @@ class RdfExportTest : AbstractXetoTest
 
                  Asset : Dict {
                    *height: Number?<minVal:0, maxVal:300>
+                   *tracked: Marker?
                  }
 
                  Equip : Asset <doc:"Line one\nLine \"two\" \\ dollar \$"> {
@@ -179,6 +198,7 @@ class RdfExportTest : AbstractXetoTest
                    equip
                    fixed: Str <invariant> "ok"
                    height: Int?<minVal:100>
+                   tracked: Marker
                    unit: Unit <quantity:"temperature">
                    percent: Number <unit:"%">
                  }
@@ -238,6 +258,7 @@ class RdfExportTest : AbstractXetoTest
     verify(first.contains("rdfs:comment \"Line one\\nLine \\\"two\\\" \\\\ dollar \$\"@en"), first)
     verify(first.contains("sh:zeroOrMorePath temp:Equip.related"), first)
     verify(first.contains("rdfs:subPropertyOf temp:Asset.height ;"), first)
+    verify(first.contains("temp:Equip.tracked\n  a sys:Marker ;\n  rdfs:subPropertyOf temp:Asset.tracked ;"), first)
     verify(first.contains("rdfs:subClassOf temp:Named, temp:Located ;"), first)
     verify(first.contains("temp:Heating rdfs:subClassOf temp:ThermalProcess ."), first)
     verify(first.contains("temp:Cooling rdfs:subClassOf temp:ThermalProcess ."), first)
@@ -434,6 +455,25 @@ class RdfExportTest : AbstractXetoTest
     address := instanceBlock(rdf, "address1")
     verify(address.contains("a sys:Entity, temp:Address ;"), address)
     verify(address.contains("temp:Address.city \"Norfolk\"^^xsd:string ;"), address)
+  }
+
+  Void testInheritedGlobalUriInstance()
+  {
+    rdf := exportWithOpts(
+      Str<|Base : Dict {
+               *baseUri: Uri?
+               *unused: Str?
+               *unusedMarker: Marker?
+             }
+
+             Site : Base
+
+             @site1: Site {
+               baseUri: Uri "https://example.com/base/"
+             }|>, Etc.makeDict(["instancesOnly":Marker.val]))
+
+    verify(rdf.contains("temp:Site.baseUri \"https://example.com/base/\"^^xsd:anyURI ;"), rdf)
+    verifyFalse(rdf.contains("unused"), rdf)
   }
 
   Void testChoiceShapesAndInstances()

--- a/src/test/testXeto/fan/RdfExportTest.fan
+++ b/src/test/testXeto/fan/RdfExportTest.fan
@@ -557,6 +557,49 @@ class RdfExportTest : AbstractXetoTest
     verifyFalse(equip.contains("temp:Equip.points"), equip)
   }
 
+  Void testQueryPathValidation()
+  {
+    verifyUnsupportedFragments(
+      Str<|Point : Dict
+           Holder : Dict {
+             values: Query<of:Point, via:"pointRef", inverse:"Point.values">
+           }|>, ["Holder.values", "cannot declare both via and inverse"])
+
+    verifyUnsupportedFragments(
+      Str<|Point : Dict
+           Holder : Dict { values: Query<of:Point, via:""> }|>,
+      ["Empty query path", "Holder.values"])
+    verifyUnsupportedFragments(
+      Str<|Point : Dict
+           Holder : Dict { values: Query<of:Point, inverse:""> }|>,
+      ["Empty query path", "Holder.values"])
+
+    verifyUnsupportedFragments(
+      Str<|Point : Dict
+           Holder : Dict { values: Query<of:Point, via:"pointRef++"> }|>,
+      ["Invalid query path", "Holder.values", "pointRef++"])
+    verifyUnsupportedFragments(
+      Str<|Point : Dict
+           Holder : Dict {
+             values: Query<of:Point, inverse:"Point.equipRef+">
+           }|>, ["Invalid query path", "Holder.values", "Point.equipRef+"])
+
+    verifyUnsupportedFragments(
+      Str<|Equip : Dict {
+             points: Query<of:Point, inverse:"Point.equips">
+           }
+           Point : Dict { equips: Query<of:Equip> }|>,
+      ["Equip.points", "must reference a via query", "Point.equips"])
+
+    rdf := export(
+      Str<|Equip : Dict {
+               points: Query<of:Point, inverse:"Point.equipRef">
+             }
+             Point : Dict { equipRef: Ref<of:Equip, maybe> }|>)
+    direct := propertyShape(rdf, "[ sh:inversePath temp:Point.equipRef ]")
+    verify(direct.contains("sh:class temp:Point ;"), direct)
+  }
+
   Void testUnsupportedListItemTypesFailClosed()
   {
     try
@@ -746,6 +789,19 @@ class RdfExportTest : AbstractXetoTest
     catch (UnsupportedErr err)
     {
       verify(err.msg.contains(expected), err.msg)
+    }
+  }
+
+  private Void verifyUnsupportedFragments(Str src, Str[] expected)
+  {
+    try
+    {
+      export(src)
+      fail("Expected unsupported RDF mapping: ${src}")
+    }
+    catch (UnsupportedErr err)
+    {
+      expected.each |fragment| { verify(err.msg.contains(fragment), err.msg) }
     }
   }
 

--- a/src/test/testXeto/fan/RdfExportTest.fan
+++ b/src/test/testXeto/fan/RdfExportTest.fan
@@ -276,7 +276,7 @@ class RdfExportTest : AbstractXetoTest
     verify(rdf.contains("rdfs:subClassOf sys:Err ;"), rdf)
     verify(propertyShape(rdf, "Envelope.failure").contains("sh:node temp:Failure ;"), rdf)
 
-    ["None", "NA", "Float", "Duration", "Version", "Buf", "Span", "Filter", "BuildVar"].each |type|
+    ["None", "NA", "Duration", "Version", "Buf", "Span", "Filter", "BuildVar"].each |type|
     {
       verifyUnsupported("Holder : Dict { value: ${type} }", "RDF scalar datatype not supported: sys::${type}")
     }
@@ -519,12 +519,22 @@ class RdfExportTest : AbstractXetoTest
                state: State
                large: Int <minVal:-9223372036854775808, maxVal:9223372036854775807>
                tiny: Number <minVal:1e-7, maxVal:1e20>
+               ratio: Float <minVal:1e-7, maxVal:1e20>
+               signedZero: Float
+               notANumber: Float
+               positiveInfinity: Float
+               negativeInfinity: Float
              }
 
              @reading1: Reading {
                state: "line\n\"quoted\"\\slash Ω"
                large: 9223372036854775807
                tiny: 1e-7
+               ratio: 1e-7
+               signedZero: -0.0
+               notANumber: "NaN"
+               positiveInfinity: "INF"
+               negativeInfinity: "-INF"
              }|>)
 
     verify(rdf.contains("\"line\\n\\\"quoted\\\"\\\\slash Ω\"^^xsd:string"), rdf)
@@ -534,6 +544,14 @@ class RdfExportTest : AbstractXetoTest
     verify(rdf.contains("sh:minInclusive 0.0000001 ;"), rdf)
     verify(rdf.contains("sh:maxInclusive 100000000000000000000 ;"), rdf)
     verify(rdf.contains("\"0.0000001\"^^xsd:decimal"), rdf)
+    verify(rdf.contains("sh:datatype xsd:double ;"), rdf)
+    verify(rdf.contains("sh:minInclusive \"1E-7\"^^xsd:double ;"), rdf)
+    verify(rdf.contains("sh:maxInclusive \"1E20\"^^xsd:double ;"), rdf)
+    verify(rdf.contains("\"1E-7\"^^xsd:double"), rdf)
+    verify(rdf.contains("\"-0\"^^xsd:double"), rdf)
+    verify(rdf.contains("\"NaN\"^^xsd:double"), rdf)
+    verify(rdf.contains("\"INF\"^^xsd:double"), rdf)
+    verify(rdf.contains("\"-INF\"^^xsd:double"), rdf)
 
     controlRdf := export("Controlled : Dict <doc:\"backspace\\u0008 form-feed\\u000C control\\u0001\">")
     verify(controlRdf.contains("rdfs:comment \"backspace\\b form-feed\\f control\\u0001\"@en"), controlRdf)
@@ -558,6 +576,13 @@ class RdfExportTest : AbstractXetoTest
         "Reading : Dict { value: Number }\n@reading1: Reading { value: \"${special}\" }",
         ["Invalid RDF decimal for", "Reading.value", "non-finite Number"])
     }
+  }
+
+  Void testNaNFloatBoundFailsClosed()
+  {
+    verifyUnsupportedFragments(
+      "Reading : Dict { value: Float <minVal:\"NaN\"> }",
+      ["Invalid numeric metadata for", "Reading.value.minVal", "NaN is not an ordered bound"])
   }
 
   Void testListShapesAndInstances()

--- a/src/test/testXeto/fan/RdfExportTest.fan
+++ b/src/test/testXeto/fan/RdfExportTest.fan
@@ -366,12 +366,126 @@ class RdfExportTest : AbstractXetoTest
     }
   }
 
+  Void testQudtMappingValidation()
+  {
+    mappings := RdfQudtMappings(
+      "fahrenheit=DEG_F\nus_dollar=USD\n",
+      "temperature=Temperature\ncurrency=Currency\n")
+    verifyEq(mappings.unitCount, 2)
+    verifyEq(mappings.quantityCount, 2)
+    verifyEq(mappings.unit(Unit.fromStr("°F")), "unit:DEG_F")
+    verifyEq(mappings.unit(Unit.fromStr("\$")), "currency:USD")
+    verifyEq(mappings.quantity(UnitQuantity.temperature), ["Temperature"])
+
+    verifyErrMsg(IOErr#, "qudt-units.props: mapping resource is empty")
+    {
+      ignored := RdfQudtMappings("", "temperature=Temperature\n")
+    }
+    verifyErrMsg(IOErr#, "qudt-quantities.props: mapping resource is empty")
+    {
+      ignored := RdfQudtMappings("fahrenheit=DEG_F\n", "")
+    }
+
+    verifyErrMsg(IOErr#, "qudt-units.props:2: duplicate mapping 'fahrenheit'; first declared on line 1")
+    {
+      ignored := RdfQudtMappings("fahrenheit=DEG_F\nfahrenheit=DEG_C\n", "temperature=Temperature\n")
+    }
+    verifyErrMsg(IOErr#, "qudt-units.props:1: expected one non-empty name=value row")
+    {
+      ignored := RdfQudtMappings("fahrenheit DEG_F\n", "temperature=Temperature\n")
+    }
+    verifyErrMsg(IOErr#, "qudt-units.props: unknown canonical Xeto unit '°F'")
+    {
+      ignored := RdfQudtMappings("°F=DEG_F\n", "temperature=Temperature\n")
+    }
+    verifyErrMsg(IOErr#, "qudt-quantities.props: empty QUDT target for 'temperature'")
+    {
+      ignored := RdfQudtMappings("fahrenheit=DEG_F\n", "temperature=Temperature,\n")
+    }
+    verifyErrMsg(IOErr#, "qudt-quantities.props: duplicate QUDT target 'Temperature' for 'temperature'")
+    {
+      ignored := RdfQudtMappings("fahrenheit=DEG_F\n", "temperature=Temperature,Temperature\n")
+    }
+
+    ns := createNamespace(["sys"])
+    lib := ns.compileTempLib("Foo : Dict {}")
+    verifyErrMsg(ArgErr#, "qudtMappings option must be RdfQudtMappings, not sys::Str")
+    {
+      RdfExporter(ns, Buf().out, Etc.makeDict(["qudtMappings":"invalid"])).start.lib(lib).end
+    }
+  }
+
+  Void testUnitAndQuantityShapesAndInstances()
+  {
+    mappings := RdfQudtMappings(
+      "fahrenheit=DEG_F\npercent=PERCENT\nkilowatt=KiloW\nus_dollar=USD\n",
+      "temperature=Temperature\npower=Power\ncurrency=Currency\n")
+    rdf := exportWithMappings(
+      Str<|Reading : Dict {
+               unit: Unit <quantity:"temperature">
+               percent: Number <unit:"%", minVal:0, maxVal:100>
+               power: Number <quantity:"power">
+               currency: Unit <quantity:"currency">
+             }
+
+             @reading1: Reading {
+               unit: Unit "°F"
+               percent: Number "50%"
+               power: Number "1kW"
+               currency: Unit "\$"
+             }|>, mappings)
+
+    verify(rdf.contains("sh:path temp:Reading.unit ;\n    sh:class qudt:Unit ;"), rdf)
+    verify(rdf.contains("sh:hasValue quantitykind:Temperature"), rdf)
+    verify(rdf.contains("sh:path temp:Reading.percent ;\n    sh:minCount 1 ;"), rdf)
+    verify(rdf.contains("sh:class qudt:QuantityValue ;"), rdf)
+    verify(rdf.contains("sh:path qudt:numericValue ;"), rdf)
+    verify(rdf.contains("sh:minInclusive 0 ;"), rdf)
+    verify(rdf.contains("sh:maxInclusive 100 ;"), rdf)
+    verify(rdf.contains("sh:path qudt:unit ;"), rdf)
+    verify(rdf.contains("sh:hasValue unit:PERCENT ;"), rdf)
+    verify(rdf.contains("sh:hasValue quantitykind:Power"), rdf)
+
+    reading := instanceBlock(rdf, "reading1")
+    verify(reading.contains("temp:Reading.unit unit:DEG_F ;"), reading)
+    verify(reading.contains("qudt:numericValue \"50\"^^xsd:decimal ;"), reading)
+    verify(reading.contains("qudt:unit unit:PERCENT"), reading)
+    verify(reading.contains("qudt:numericValue \"1\"^^xsd:decimal ;"), reading)
+    verify(reading.contains("qudt:unit unit:KiloW"), reading)
+    verify(reading.contains("temp:Reading.currency currency:USD ;"), reading)
+
+    // QUDT ontology facts are external validation inputs, not copied output.
+    verifyFalse(rdf.contains("unit:DEG_F a qudt:Unit"), rdf)
+    verifyFalse(rdf.contains("quantitykind:Temperature skos:broader"), rdf)
+  }
+
+  Void testUnmappedUnitFailsClosed()
+  {
+    mappings := RdfQudtMappings("percent=PERCENT\n", "temperature=Temperature\n")
+    verifyErrMsg(UnsupportedErr#, "No reviewed QUDT mapping for Xeto unit 'fahrenheit'")
+    {
+      exportWithMappings(
+        Str<|Reading : Dict { unit: Unit }
+               @reading1: Reading { unit: Unit "°F" }|>, mappings)
+    }
+  }
+
   private Str export(Str src)
   {
     ns  := createNamespace(["sys"])
     lib := ns.compileTempLib(src)
     buf := Buf()
     RdfExporter(ns, buf.out, Etc.dict0).start.lib(lib).end
+    return buf.flip.readAllStr.replace(lib.name, "temp")
+  }
+
+  private Str exportWithMappings(Str src, RdfQudtMappings mappings)
+  {
+    ns  := createNamespace(["sys"])
+    lib := ns.compileTempLib(src)
+    buf := Buf()
+    opts := Etc.makeDict(["qudtMappings":mappings])
+    RdfExporter(ns, buf.out, opts).start.lib(lib).end
     return buf.flip.readAllStr.replace(lib.name, "temp")
   }
 

--- a/src/test/testXeto/fan/RdfExportTest.fan
+++ b/src/test/testXeto/fan/RdfExportTest.fan
@@ -676,12 +676,13 @@ class RdfExportTest : AbstractXetoTest
     names := propertyShape(rdf, "Batch.names")
     verify(names.contains("sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;"), names)
     verify(names.contains("sh:datatype xsd:string ;"), names)
-    verify(names.contains("sh:minCount 2 ;"), names)
-    verify(names.contains("sh:maxCount 3 ;"), names)
+    verify(rdf.contains("sh:path [ sh:zeroOrMorePath rdf:rest ] ;"), rdf)
+    verify(rdf.contains("sh:minCount 3 ;"), rdf)
+    verify(rdf.contains("sh:maxCount 4 ;"), rdf)
 
     numbers := propertyShape(rdf, "Batch.numbers")
     verify(numbers.contains("sh:datatype xsd:double ;"), numbers)
-    verify(numbers.contains("sh:minCount 1 ;"), numbers)
+    verify(rdf.contains("sh:minCount 2 ;"), rdf)
 
     addresses := propertyShape(rdf, "Batch.addresses")
     verify(addresses.contains("sh:class temp:Address ;"), addresses)

--- a/src/test/testXeto/fan/RdfExportTest.fan
+++ b/src/test/testXeto/fan/RdfExportTest.fan
@@ -221,7 +221,7 @@ class RdfExportTest : AbstractXetoTest
     equip := instanceBlock(first, "equip1")
     verify(equip.contains("temp:Equip.label \"AHU-1\"^^xsd:string ;"), equip)
     verify(equip.contains("temp:Equip.observedAt \"02:30:00\"^^xsd:time ;"), equip)
-    verify(equip.contains("temp:Equip.timestamp \"2026-08-18T10:00:00Z UTC\"^^xsd:dateTime ;"), equip)
+    verify(equip.contains("temp:Equip.timestamp \"2026-08-18T10:00:00Z\"^^xsd:dateTime ;"), equip)
     verify(equip.contains("temp:Equip.source \"https://example.com/a?x=1&y=2\"^^xsd:anyURI ;"), equip)
     verify(equip.contains("temp:Equip.anything \"free\"^^xsd:string ;"), equip)
     verify(equip.contains("temp:Equip.siteRef temp:site1 ;"), equip)
@@ -494,6 +494,74 @@ class RdfExportTest : AbstractXetoTest
     verify(instances.contains("sys:hasMarker temp:Widget.widget"), instances)
     verifyFalse(instances.contains("a sh:NodeShape"), instances)
     verifyFalse(instances.contains("a owl:Ontology"), instances)
+  }
+
+  Void testMixinInstancePropertyOwnership()
+  {
+    rdf := export(
+      Str<|+Entity { orgRef: Ref<of:Org> }
+             Org : Dict
+             Employee : Entity
+
+             @org1: Org {}
+             @entity1: Entity { orgRef: @org1 }
+             @employee1: Employee { orgRef: @org1 }|>)
+
+    entity := instanceBlock(rdf, "entity1")
+    verify(entity.contains("temp:Entity.orgRef temp:org1 ;"), entity)
+    verifyFalse(entity.contains("sys:Entity.orgRef"), entity)
+
+    employee := instanceBlock(rdf, "employee1")
+    verify(employee.contains("temp:Entity.orgRef temp:org1 ;"), employee)
+    verifyFalse(employee.contains("temp:Employee.orgRef"), employee)
+  }
+
+  Void testDirectInstanceFindsInstalledMixinProperty()
+  {
+    ns := createNamespace(["sys", "hx"])
+    instance := Etc.makeDict([
+      "id": Ref("hx::entity1"),
+      "spec": Ref("sys::Entity"),
+      "mod": DateTime("2026-08-26T12:00:00Z UTC")])
+    buf := Buf()
+    RdfExporter(ns, buf.out, Etc.dict0).start.instance(instance).end
+    rdf := buf.flip.readAllStr
+
+    verify(rdf.contains("hx:Entity.mod \"2026-08-26T12:00:00Z\"^^xsd:dateTime ;"), rdf)
+    verifyFalse(rdf.contains("sys:Entity.mod"), rdf)
+  }
+
+  Void testAmbiguousMixinInstancePropertyFailsClosed()
+  {
+    ns := createNamespace(["sys", "hx"])
+    lib := ns.compileTempLib(
+      Str<|+Entity { mod: DateTime? }
+             @entity1: Entity { mod: 2026-08-26T12:00:00Z }|>)
+    try
+    {
+      RdfExporter(ns, Buf().out, Etc.dict0).start.lib(lib).end
+      fail("Expected ambiguous mixin instance property to fail closed")
+    }
+    catch (UnsupportedErr err)
+    {
+      verify(err.msg.startsWith("Ambiguous mixin property for sys::Entity.mod:"), err.msg)
+      verify(err.msg.contains("hx::Entity.mod"), err.msg)
+      verify(err.msg.contains("${lib.name}::Entity.mod"), err.msg)
+    }
+  }
+
+  Void testMissingMixinTargetRejectedAtCompileBoundary()
+  {
+    ns := createNamespace(["sys"])
+    try
+    {
+      ns.compileTempLib("+Missing { value: Str? }")
+      fail("Expected missing mixin target to fail during compilation")
+    }
+    catch (XetoCompilerErr err)
+    {
+      verify(err.msg.contains("Unresolved spec: Missing"), err.msg)
+    }
   }
 
   Void testMissingReferenceDoesNotExportTypeDefault()

--- a/src/test/testXeto/fan/RdfExportTest.fan
+++ b/src/test/testXeto/fan/RdfExportTest.fan
@@ -482,6 +482,33 @@ class RdfExportTest : AbstractXetoTest
     verifyFalse(equip.contains("sys:hasMarker"), equip)
   }
 
+  Void testLibraryProjectionProfiles()
+  {
+    src := Str<|Widget : Dict { widget }
+                 @widget1: Widget {}|>
+    schema := exportWithOpts(src, Etc.makeDict(["schemaOnly":Marker.val]))
+    verify(schema.contains("temp:Widget\n  a sys:Class"), schema)
+    verifyFalse(schema.contains("temp:widget1"), schema)
+
+    instances := exportWithOpts(src, Etc.makeDict(["instancesOnly":Marker.val]))
+    verify(instances.contains("temp:widget1"), instances)
+    verify(instances.contains("sys:hasMarker temp:Widget.widget"), instances)
+    verifyFalse(instances.contains("a sh:NodeShape"), instances)
+    verifyFalse(instances.contains("a owl:Ontology"), instances)
+  }
+
+  Void testMissingReferenceDoesNotExportTypeDefault()
+  {
+    rdf := export(
+      Str<|Target : Dict
+             Holder : Dict { targetRef: Ref<of:Target> }
+
+             @holder1: Holder {}|>)
+
+    holder := instanceBlock(rdf, "holder1")
+    verifyFalse(holder.contains("Holder.targetRef"), holder)
+  }
+
   Void testListShapesAndInstances()
   {
     rdf := export(
@@ -737,10 +764,15 @@ class RdfExportTest : AbstractXetoTest
 
   private Str export(Str src)
   {
+    return exportWithOpts(src, Etc.dict0)
+  }
+
+  private Str exportWithOpts(Str src, Dict opts)
+  {
     ns  := createNamespace(["sys"])
     lib := ns.compileTempLib(src)
     buf := Buf()
-    RdfExporter(ns, buf.out, Etc.dict0).start.lib(lib).end
+    RdfExporter(ns, buf.out, opts).start.lib(lib).end
     return buf.flip.readAllStr.replace(lib.name, "temp")
   }
 

--- a/src/test/testXeto/fan/RdfExportTest.fan
+++ b/src/test/testXeto/fan/RdfExportTest.fan
@@ -235,8 +235,7 @@ class RdfExportTest : AbstractXetoTest
     firstName := equip.index("\"first\"^^xsd:string")
     secondName := equip.index("\"second\"^^xsd:string")
     verify(firstName != null && secondName != null && firstName < secondName, equip)
-    verify(first.contains("rdfs:comment " + Str<|"""|> + "\n    Line one"), first)
-    verify(first.contains("Line \"two\" \\\\ dollar \$"), first)
+    verify(first.contains("rdfs:comment \"Line one\\nLine \\\"two\\\" \\\\ dollar \$\"@en"), first)
     verify(first.contains("sh:zeroOrMorePath temp:Equip.related"), first)
     verify(first.contains("rdfs:subPropertyOf temp:Asset.height ;"), first)
     verify(first.contains("rdfs:subClassOf temp:Named, temp:Located ;"), first)
@@ -507,6 +506,58 @@ class RdfExportTest : AbstractXetoTest
 
     holder := instanceBlock(rdf, "holder1")
     verifyFalse(holder.contains("Holder.targetRef"), holder)
+  }
+
+  Void testLexicalSerialization()
+  {
+    rdf := export(
+      Str<|State : Enum {
+               unusual <key:"line\n\"quoted\"\\slash Ω">
+             }
+
+             Reading : Dict <doc:"line\n\"quoted\"\\slash Ω"> {
+               state: State
+               large: Int <minVal:-9223372036854775808, maxVal:9223372036854775807>
+               tiny: Number <minVal:1e-7, maxVal:1e20>
+             }
+
+             @reading1: Reading {
+               state: "line\n\"quoted\"\\slash Ω"
+               large: 9223372036854775807
+               tiny: 1e-7
+             }|>)
+
+    verify(rdf.contains("\"line\\n\\\"quoted\\\"\\\\slash Ω\"^^xsd:string"), rdf)
+    verify(rdf.contains("rdfs:comment \"line\\n\\\"quoted\\\"\\\\slash Ω\"@en"), rdf)
+    verify(rdf.contains("sh:minInclusive -9223372036854775808 ;"), rdf)
+    verify(rdf.contains("sh:maxInclusive 9223372036854775807 ;"), rdf)
+    verify(rdf.contains("sh:minInclusive 0.0000001 ;"), rdf)
+    verify(rdf.contains("sh:maxInclusive 100000000000000000000 ;"), rdf)
+    verify(rdf.contains("\"0.0000001\"^^xsd:decimal"), rdf)
+
+    controlRdf := export("Controlled : Dict <doc:\"backspace\\u0008 form-feed\\u000C control\\u0001\">")
+    verify(controlRdf.contains("rdfs:comment \"backspace\\b form-feed\\f control\\u0001\"@en"), controlRdf)
+
+    ns := createNamespace(["sys"])
+    sysVersion := ns.lib("sys").version
+    ["sys::tail.", "sys::name~one", "sys::op:name"].each |id|
+    {
+      instance := Etc.makeDict(["id":Ref(id), "spec":Ref("sys::Dict")])
+      buf := Buf()
+      RdfExporter(ns, buf.out, Etc.dict0).start.instance(instance).end
+      rendered := buf.flip.readAllStr
+      verify(rendered.contains("<http://xeto.dev/rdf/sys-${sysVersion}#"), rendered)
+    }
+  }
+
+  Void testNonFiniteDecimalFailsClosed()
+  {
+    ["NaN", "INF", "-INF"].each |special|
+    {
+      verifyUnsupportedFragments(
+        "Reading : Dict { value: Number }\n@reading1: Reading { value: \"${special}\" }",
+        ["Invalid RDF decimal for", "Reading.value", "non-finite Number"])
+    }
   }
 
   Void testListShapesAndInstances()

--- a/src/test/testXeto/fan/RdfExportTest.fan
+++ b/src/test/testXeto/fan/RdfExportTest.fan
@@ -133,12 +133,191 @@ class RdfExportTest : AbstractXetoTest
     verifyEq(export(src), export(src))
   }
 
+  Void testCompleteSupportedProfileClosure()
+  {
+    src := Str<|Code : Scalar <pattern:"[A-Z]{2}">
+
+                 Suit : Enum { clubs <key:"Clubs"> }
+                 HeatingProcess : Choice
+                 HotWaterHeating : HeatingProcess { hotWaterHeating }
+                 SteamHeating : HeatingProcess { steamHeating }
+
+                 Site : Dict { dis: Str }
+                 Related : Dict
+                 Address : Dict { city: Str }
+                 Named : Dict { dis: Str }
+                 Located : Dict { geoCity: Str }
+                 NamedLocation : Named & Located
+                 Heating : Dict
+                 Cooling : Dict
+                 ThermalProcess : Heating | Cooling
+
+                 Asset : Dict {
+                   *height: Number?<minVal:0, maxVal:300>
+                 }
+
+                 Equip : Asset <doc:"Line one\nLine \"two\" \\ dollar \$"> {
+                   label: Str <nonEmpty, minSize:2, maxSize:40>
+                   code: Code
+                   count: Int <minVal:1, maxVal:60>
+                   value: Number
+                   enabled: Bool
+                   commissioned: Date
+                   observedAt: Time
+                   timestamp: DateTime
+                   source: Uri
+                   zone: TimeZone
+                   anything: Obj
+                   suit: Suit
+                   siteRef: Ref<of:Site>
+                   related: MultiRef?<of:Related>
+                   address: Address
+                   names: List<of:Str, minSize:2, maxSize:3>
+                   addresses: List<of:Address, nonEmpty>
+                   heatingProcesses: HeatingProcess <multiChoice>
+                   points: Query<of:Related, via:"related*">
+                   equip
+                   fixed: Str <invariant> "ok"
+                   height: Int?<minVal:100>
+                   unit: Unit <quantity:"temperature">
+                   percent: Number <unit:"%">
+                 }
+
+                 @site1: Site { dis:"HQ" }
+                 @related1: Related {}
+                 @equip1: Equip {
+                   label: "AHU-1"
+                   code: Code "AB"
+                   count: 7
+                   value: 1.5
+                   enabled: "true"
+                   commissioned: 2026-08-18
+                   observedAt: 02:30:00
+                   timestamp: 2026-08-18T10:00:00Z
+                   source: Uri "https://example.com/a?x=1&y=2"
+                   zone: TimeZone "Chicago"
+                   anything: "free"
+                   suit: "Clubs"
+                   siteRef: @site1
+                   related: MultiRef { @related1 }
+                   address: Address { city:"Richmond" }
+                   names: {"first", "second"}
+                   addresses: { Address { city:"Norfolk" } }
+                   hotWaterHeating
+                   steamHeating
+                   equip
+                   imported
+                   unit: Unit "°F"
+                   percent: Number "50%"
+                 }|>
+
+    mappings := RdfQudtMappings(
+      "fahrenheit=DEG_F\npercent=PERCENT\n",
+      "temperature=Temperature\n")
+    first := exportWithMappings(src, mappings)
+    second := exportWithMappings(src, mappings)
+    verifyEq(first, second)
+
+    equip := instanceBlock(first, "equip1")
+    verify(equip.contains("temp:Equip.label \"AHU-1\"^^xsd:string ;"), equip)
+    verify(equip.contains("temp:Equip.observedAt \"02:30:00\"^^xsd:time ;"), equip)
+    verify(equip.contains("temp:Equip.timestamp \"2026-08-18T10:00:00Z UTC\"^^xsd:dateTime ;"), equip)
+    verify(equip.contains("temp:Equip.source \"https://example.com/a?x=1&y=2\"^^xsd:anyURI ;"), equip)
+    verify(equip.contains("temp:Equip.anything \"free\"^^xsd:string ;"), equip)
+    verify(equip.contains("temp:Equip.siteRef temp:site1 ;"), equip)
+    verify(equip.contains("temp:Equip.address ["), equip)
+    verify(equip.contains("temp:Equip.names ("), equip)
+    verify(equip.contains("temp:Equip.heatingProcesses temp:HotWaterHeating ;"), equip)
+    verify(equip.contains("qudt:numericValue \"50\"^^xsd:decimal ;"), equip)
+    verify(equip.contains("sys:hasMarker temp:Equip.imported ;"), equip)
+    verifyFalse(equip.contains("temp:Equip.points"), equip)
+
+    firstName := equip.index("\"first\"^^xsd:string")
+    secondName := equip.index("\"second\"^^xsd:string")
+    verify(firstName != null && secondName != null && firstName < secondName, equip)
+    verify(first.contains("rdfs:comment " + Str<|"""|> + "\n    Line one"), first)
+    verify(first.contains("Line \"two\" \\\\ dollar \$"), first)
+    verify(first.contains("sh:zeroOrMorePath temp:Equip.related"), first)
+    verify(first.contains("rdfs:subPropertyOf temp:Asset.height ;"), first)
+    verify(first.contains("rdfs:subClassOf temp:Named, temp:Located ;"), first)
+    verify(first.contains("temp:Heating rdfs:subClassOf temp:ThermalProcess ."), first)
+    verify(first.contains("temp:Cooling rdfs:subClassOf temp:ThermalProcess ."), first)
+    verifyFalse(propertyShape(first, "Equip.zone").contains("sh:in"), first)
+  }
+
   Void testUnsupportedSystemScalarFailsClosed()
   {
     verifyErrMsg(UnsupportedErr#, "RDF scalar datatype not supported: sys::Version")
     {
       export(Str<|Reading : Dict { version: Version }|>)
     }
+  }
+
+  Void testUnmappedMetadataIsOmitted()
+  {
+    plain := export(Str<|Person : Dict { dis: Str }|>)
+    annotated := export(
+      Str<|+Spec { icon: Str? }
+
+             Person : Dict <icon:"user"> {
+               dis: Str <icon:"label">
+             }|>)
+
+    verifyEq(resourceBlock(annotated, "temp:Person"), resourceBlock(plain, "temp:Person"))
+    verifyEq(resourceBlock(annotated, "temp:Person.dis"), resourceBlock(plain, "temp:Person.dis"))
+    verifyFalse(annotated.contains("icon"), annotated)
+  }
+
+  Void testOtherCoreTypeInventory()
+  {
+    rdf := export(
+      Str<|Failure : Err
+             Envelope : Dict { failure: Failure? }|>)
+    verify(rdf.contains("temp:Failure\n  a sys:Class ;"), rdf)
+    verify(rdf.contains("rdfs:subClassOf sys:Err ;"), rdf)
+    verify(propertyShape(rdf, "Envelope.failure").contains("sh:node temp:Failure ;"), rdf)
+
+    ["None", "NA", "Float", "Duration", "Version", "Buf", "Span", "Filter", "BuildVar"].each |type|
+    {
+      verifyUnsupported("Holder : Dict { value: ${type} }", "RDF scalar datatype not supported: sys::${type}")
+    }
+    verifyUnsupported("Holder : Dict { value: Grid }", "RDF Grid mapping not supported")
+    verifyUnsupported("Holder : Dict { value: Collection }", "RDF Collection mapping not supported")
+    verifyUnsupported("Holder : Dict { value: Func }", "RDF Func mapping not supported")
+    verifyUnsupported("Holder : Dict { value: Interface }", "RDF Interface mapping not supported")
+    verifyUnsupported("Holder : Dict { value: Funcs }", "RDF Interface mapping not supported")
+  }
+
+  Void testClosureDiagnosticsFailClosed()
+  {
+    try
+    {
+      export(Str<|Point : Dict
+                   Equip : Dict { points: Query { point: Point } }|>)
+      fail("Expected required query body member to fail closed")
+    }
+    catch (UnsupportedErr err)
+    {
+      verify(err.msg.contains("RDF query body mapping not supported for required member"), err.msg)
+      verify(err.msg.endsWith("::Equip.points.point"), err.msg)
+    }
+
+    try
+    {
+      export(Str<|Node : Dict { parent: Ref<of:This> }|>)
+      fail("Expected parent-relative Ref to fail closed")
+    }
+    catch (UnsupportedErr err)
+    {
+      verify(err.msg.contains("RDF parent-relative This mapping not supported for"), err.msg)
+      verify(err.msg.endsWith("::Node.parent"), err.msg)
+    }
+
+    ns := createNamespace(["sys"])
+    colonId := Etc.makeDict(["id":Ref("sys::op:bad"), "spec":Ref("sys::Dict")])
+    buf := Buf()
+    RdfExporter(ns, buf.out, Etc.dict0).start.instance(colonId).end
+    verify(buf.flip.readAllStr.contains("#op:bad>"))
   }
 
   Void testStructuredValueShapes()
@@ -341,6 +520,43 @@ class RdfExportTest : AbstractXetoTest
     verify(richmond != null && norfolk != null && richmond < norfolk, batch)
   }
 
+  Void testQueryPropertyPaths()
+  {
+    rdf := export(
+      Str<|Equip : Dict {
+               points: Query<of:Point, inverse:"Point.equips">
+               plain: Query<of:Point>
+             }
+
+             Point : Dict {
+               equipRef: Ref<of:Equip>
+               equips: Query<of:Equip, via:"equipRef+">
+             }
+
+             @equip1: Equip {}
+             @point1: Point { equipRef: @equip1 }|>)
+
+    points := propertyShape(rdf, "[ sh:oneOrMorePath [ sh:inversePath temp:Point.equipRef ] ]")
+    verify(points.contains("sh:class temp:Point ;"), points)
+    verifyFalse(points.contains("sh:minCount"), points)
+    verifyFalse(points.contains("sh:maxCount"), points)
+
+    equips := propertyShape(rdf, "[ sh:oneOrMorePath temp:Point.equipRef ]")
+    verify(equips.contains("sh:class temp:Equip ;"), equips)
+    verifyFalse(equips.contains("sh:minCount"), equips)
+    verifyFalse(equips.contains("sh:maxCount"), equips)
+
+    plain := propertyShape(rdf, "Equip.plain")
+    verify(plain.contains("sh:class temp:Point ;"), plain)
+    verifyFalse(plain.contains("sh:minCount"), plain)
+    verifyFalse(plain.contains("sh:maxCount"), plain)
+
+    point := instanceBlock(rdf, "point1")
+    verify(point.contains("temp:Point.equipRef temp:equip1 ;"), point)
+    equip := instanceBlock(rdf, "equip1")
+    verifyFalse(equip.contains("temp:Equip.points"), equip)
+  }
+
   Void testUnsupportedListItemTypesFailClosed()
   {
     try
@@ -491,7 +707,9 @@ class RdfExportTest : AbstractXetoTest
 
   private Str propertyShape(Str rdf, Str property)
   {
-    path := "sh:path temp:${property} ;"
+    path := property.startsWith("[")
+      ? "sh:path ${property} ;"
+      : "sh:path temp:${property} ;"
     start := rdf.index(path)
     if (start == null) throw Err("Missing property shape for ${property}")
     close := "  ] ;"
@@ -516,6 +734,19 @@ class RdfExportTest : AbstractXetoTest
     end := rdf.index("\n.\n", start)
     if (end == null) throw Err("Unterminated resource ${resource}")
     return rdf[start..<(end + 3)]
+  }
+
+  private Void verifyUnsupported(Str src, Str expected)
+  {
+    try
+    {
+      export(src)
+      fail("Expected unsupported RDF mapping: ${src}")
+    }
+    catch (UnsupportedErr err)
+    {
+      verify(err.msg.contains(expected), err.msg)
+    }
   }
 
   private Int countMatches(Str source, Str match)

--- a/src/test/testXeto/fan/RdfExportTest.fan
+++ b/src/test/testXeto/fan/RdfExportTest.fan
@@ -64,7 +64,7 @@ class RdfExportTest : AbstractXetoTest
     verify(rdf.contains("sh:path temp:Reading.count ;\n    sh:datatype xsd:integer ;"))
     verify(rdf.contains("sh:minInclusive 1 ;"))
     verify(rdf.contains("sh:maxInclusive 60 ;"))
-    verify(rdf.contains("sh:path temp:Reading.value ;\n    sh:datatype xsd:decimal ;"))
+    verify(rdf.contains("sh:path temp:Reading.value ;\n    sh:datatype xsd:double ;"))
     verify(rdf.contains("sh:path temp:Reading.enabled ;\n    sh:datatype xsd:boolean ;"))
     verify(rdf.contains("sh:path temp:Reading.commissioned ;\n    sh:datatype xsd:date ;"))
     verify(rdf.contains("sh:path temp:Reading.code ;\n    sh:datatype xsd:string ;"))
@@ -81,7 +81,7 @@ class RdfExportTest : AbstractXetoTest
   {
     rdf := export(
       Str<|Reading : Dict {
-               decimal: Number <minVal:1.5, maxVal:2.5>
+               value: Number <minVal:1.5, maxVal:2.5>
                observedAt: Time
                timestamp: DateTime
                source: Uri
@@ -94,10 +94,10 @@ class RdfExportTest : AbstractXetoTest
                defaulted: Str "fallback"
              }|>)
 
-    decimal := propertyShape(rdf, "Reading.decimal")
-    verify(decimal.contains("sh:datatype xsd:decimal ;"))
-    verify(decimal.contains("sh:minInclusive 1.5 ;"))
-    verify(decimal.contains("sh:maxInclusive 2.5 ;"))
+    value := propertyShape(rdf, "Reading.value")
+    verify(value.contains("sh:datatype xsd:double ;"))
+    verify(value.contains("sh:minInclusive \"1.5\"^^xsd:double ;"))
+    verify(value.contains("sh:maxInclusive \"2.5\"^^xsd:double ;"))
 
     verify(propertyShape(rdf, "Reading.observedAt").contains("sh:datatype xsd:time ;"))
     verify(propertyShape(rdf, "Reading.timestamp").contains("sh:datatype xsd:dateTime ;"))
@@ -228,7 +228,7 @@ class RdfExportTest : AbstractXetoTest
     verify(equip.contains("temp:Equip.address ["), equip)
     verify(equip.contains("temp:Equip.names ("), equip)
     verify(equip.contains("temp:Equip.heatingProcesses temp:HotWaterHeating ;"), equip)
-    verify(equip.contains("qudt:numericValue \"50\"^^xsd:decimal ;"), equip)
+    verify(equip.contains("qudt:numericValue \"50.0\"^^xsd:double ;"), equip)
     verify(equip.contains("sys:hasMarker temp:Equip.imported ;"), equip)
     verifyFalse(equip.contains("temp:Equip.points"), equip)
 
@@ -541,14 +541,14 @@ class RdfExportTest : AbstractXetoTest
     verify(rdf.contains("rdfs:comment \"line\\n\\\"quoted\\\"\\\\slash Ω\"@en"), rdf)
     verify(rdf.contains("sh:minInclusive -9223372036854775808 ;"), rdf)
     verify(rdf.contains("sh:maxInclusive 9223372036854775807 ;"), rdf)
-    verify(rdf.contains("sh:minInclusive 0.0000001 ;"), rdf)
-    verify(rdf.contains("sh:maxInclusive 100000000000000000000 ;"), rdf)
-    verify(rdf.contains("\"0.0000001\"^^xsd:decimal"), rdf)
+    verify(rdf.contains("sh:minInclusive \"1.0E-7\"^^xsd:double ;"), rdf)
+    verify(rdf.contains("sh:maxInclusive \"1.0E20\"^^xsd:double ;"), rdf)
+    verify(rdf.contains("\"1.0E-7\"^^xsd:double"), rdf)
     verify(rdf.contains("sh:datatype xsd:double ;"), rdf)
-    verify(rdf.contains("sh:minInclusive \"1E-7\"^^xsd:double ;"), rdf)
-    verify(rdf.contains("sh:maxInclusive \"1E20\"^^xsd:double ;"), rdf)
-    verify(rdf.contains("\"1E-7\"^^xsd:double"), rdf)
-    verify(rdf.contains("\"-0\"^^xsd:double"), rdf)
+    verify(rdf.contains("sh:minInclusive \"1.0E-7\"^^xsd:double ;"), rdf)
+    verify(rdf.contains("sh:maxInclusive \"1.0E20\"^^xsd:double ;"), rdf)
+    verify(rdf.contains("\"1.0E-7\"^^xsd:double"), rdf)
+    verify(rdf.contains("\"-0.0\"^^xsd:double"), rdf)
     verify(rdf.contains("\"NaN\"^^xsd:double"), rdf)
     verify(rdf.contains("\"INF\"^^xsd:double"), rdf)
     verify(rdf.contains("\"-INF\"^^xsd:double"), rdf)
@@ -568,14 +568,14 @@ class RdfExportTest : AbstractXetoTest
     }
   }
 
-  Void testNonFiniteDecimalFailsClosed()
+  Void testNumberSpecialValuesUseDouble()
   {
-    ["NaN", "INF", "-INF"].each |special|
-    {
-      verifyUnsupportedFragments(
-        "Reading : Dict { value: Number }\n@reading1: Reading { value: \"${special}\" }",
-        ["Invalid RDF decimal for", "Reading.value", "non-finite Number"])
-    }
+    rdf := export(
+      "Reading : Dict { nan: Number, pos: Number, neg: Number }\n" +
+      "@reading1: Reading { nan: \"NaN\", pos: \"INF\", neg: \"-INF\" }")
+    verify(rdf.contains("\"NaN\"^^xsd:double"), rdf)
+    verify(rdf.contains("\"INF\"^^xsd:double"), rdf)
+    verify(rdf.contains("\"-INF\"^^xsd:double"), rdf)
   }
 
   Void testNaNFloatBoundFailsClosed()
@@ -612,7 +612,7 @@ class RdfExportTest : AbstractXetoTest
     verify(names.contains("sh:maxCount 3 ;"), names)
 
     numbers := propertyShape(rdf, "Batch.numbers")
-    verify(numbers.contains("sh:datatype xsd:decimal ;"), numbers)
+    verify(numbers.contains("sh:datatype xsd:double ;"), numbers)
     verify(numbers.contains("sh:minCount 1 ;"), numbers)
 
     addresses := propertyShape(rdf, "Batch.addresses")
@@ -622,8 +622,8 @@ class RdfExportTest : AbstractXetoTest
     alpha := batch.index("\"alpha\"^^xsd:string")
     beta  := batch.index("\"beta\"^^xsd:string")
     verify(alpha != null && beta != null && alpha < beta, batch)
-    verify(batch.contains("\"1\"^^xsd:decimal"), batch)
-    verify(batch.contains("\"2.5\"^^xsd:decimal"), batch)
+    verify(batch.contains("\"1.0\"^^xsd:double"), batch)
+    verify(batch.contains("\"2.5\"^^xsd:double"), batch)
     richmond := batch.index("\"Richmond\"^^xsd:string")
     norfolk  := batch.index("\"Norfolk\"^^xsd:string")
     verify(richmond != null && norfolk != null && richmond < norfolk, batch)
@@ -808,17 +808,17 @@ class RdfExportTest : AbstractXetoTest
     verify(rdf.contains("sh:path temp:Reading.percent ;\n    sh:minCount 1 ;"), rdf)
     verify(rdf.contains("sh:class qudt:QuantityValue ;"), rdf)
     verify(rdf.contains("sh:path qudt:numericValue ;"), rdf)
-    verify(rdf.contains("sh:minInclusive 0 ;"), rdf)
-    verify(rdf.contains("sh:maxInclusive 100 ;"), rdf)
+    verify(rdf.contains("sh:minInclusive \"0.0\"^^xsd:double ;"), rdf)
+    verify(rdf.contains("sh:maxInclusive \"100.0\"^^xsd:double ;"), rdf)
     verify(rdf.contains("sh:path qudt:unit ;"), rdf)
     verify(rdf.contains("sh:hasValue unit:PERCENT ;"), rdf)
     verify(rdf.contains("sh:hasValue quantitykind:Power"), rdf)
 
     reading := instanceBlock(rdf, "reading1")
     verify(reading.contains("temp:Reading.unit unit:DEG_F ;"), reading)
-    verify(reading.contains("qudt:numericValue \"50\"^^xsd:decimal ;"), reading)
+    verify(reading.contains("qudt:numericValue \"50.0\"^^xsd:double ;"), reading)
     verify(reading.contains("qudt:unit unit:PERCENT"), reading)
-    verify(reading.contains("qudt:numericValue \"1\"^^xsd:decimal ;"), reading)
+    verify(reading.contains("qudt:numericValue \"1.0\"^^xsd:double ;"), reading)
     verify(reading.contains("qudt:unit unit:KiloW"), reading)
     verify(reading.contains("temp:Reading.currency currency:USD ;"), reading)
 

--- a/src/test/testXeto/fan/RdfExportTest.fan
+++ b/src/test/testXeto/fan/RdfExportTest.fan
@@ -252,6 +252,120 @@ class RdfExportTest : AbstractXetoTest
     verify(address.contains("temp:Address.city \"Norfolk\"^^xsd:string ;"), address)
   }
 
+  Void testChoiceShapesAndInstances()
+  {
+    rdf := export(
+      Str<|HeatingProcess : Choice
+             HotWaterHeating : HeatingProcess { hotWaterHeating }
+             SteamHeating : HeatingProcess { steamHeating }
+
+             RequiredEquip : Dict { heatingProcess: HeatingProcess }
+             OptionalEquip : Dict { heatingProcess: HeatingProcess? }
+             MultiEquip : Dict { heatingProcesses: HeatingProcess <multiChoice> }
+             OptionalMultiEquip : Dict { heatingProcesses: HeatingProcess? <multiChoice> }
+
+             @equip1: MultiEquip {
+               hotWaterHeating
+               steamHeating
+             }|>)
+
+    hotWater := resourceBlock(rdf, "temp:HotWaterHeating")
+    verify(hotWater.contains("rdfs:subClassOf temp:HeatingProcess ;"), hotWater)
+    verify(hotWater.contains("sys:hasMarker temp:HotWaterHeating.hotWaterHeating ;"), hotWater)
+    verify(rdf.contains("temp:HotWaterHeating.hotWaterHeating\n  a sys:Marker ;"), rdf)
+
+    required := propertyShape(rdf, "RequiredEquip.heatingProcess")
+    verify(required.contains("sh:in (temp:HotWaterHeating temp:SteamHeating) ;"), required)
+    verify(required.contains("sh:minCount 1 ;"), required)
+    verify(required.contains("sh:maxCount 1 ;"), required)
+
+    optional := propertyShape(rdf, "OptionalEquip.heatingProcess")
+    verifyFalse(optional.contains("sh:minCount"), optional)
+    verify(optional.contains("sh:maxCount 1 ;"), optional)
+
+    multi := propertyShape(rdf, "MultiEquip.heatingProcesses")
+    verify(multi.contains("sh:minCount 1 ;"), multi)
+    verifyFalse(multi.contains("sh:maxCount"), multi)
+
+    optionalMulti := propertyShape(rdf, "OptionalMultiEquip.heatingProcesses")
+    verifyFalse(optionalMulti.contains("sh:minCount"), optionalMulti)
+    verifyFalse(optionalMulti.contains("sh:maxCount"), optionalMulti)
+
+    equip := instanceBlock(rdf, "equip1")
+    verify(equip.contains("temp:MultiEquip.heatingProcesses temp:HotWaterHeating ;"), equip)
+    verify(equip.contains("temp:MultiEquip.heatingProcesses temp:SteamHeating ;"), equip)
+    verifyFalse(equip.contains("sys:hasMarker"), equip)
+  }
+
+  Void testListShapesAndInstances()
+  {
+    rdf := export(
+      Str<|Address : Dict { city: Str }
+
+             Batch : Dict {
+               names: List <of:Str, minSize:2, maxSize:3>
+               numbers: List <of:Number, nonEmpty>
+               addresses: List <of:Address>
+             }
+
+             @batch1: Batch {
+               names: {"alpha", "beta"}
+               numbers: {1, 2.5}
+               addresses: {
+                 Address { city: "Richmond" },
+                 Address { city: "Norfolk" }
+               }
+             }|>)
+
+    names := propertyShape(rdf, "Batch.names")
+    verify(names.contains("sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;"), names)
+    verify(names.contains("sh:datatype xsd:string ;"), names)
+    verify(names.contains("sh:minCount 2 ;"), names)
+    verify(names.contains("sh:maxCount 3 ;"), names)
+
+    numbers := propertyShape(rdf, "Batch.numbers")
+    verify(numbers.contains("sh:datatype xsd:decimal ;"), numbers)
+    verify(numbers.contains("sh:minCount 1 ;"), numbers)
+
+    addresses := propertyShape(rdf, "Batch.addresses")
+    verify(addresses.contains("sh:class temp:Address ;"), addresses)
+
+    batch := instanceBlock(rdf, "batch1")
+    alpha := batch.index("\"alpha\"^^xsd:string")
+    beta  := batch.index("\"beta\"^^xsd:string")
+    verify(alpha != null && beta != null && alpha < beta, batch)
+    verify(batch.contains("\"1\"^^xsd:decimal"), batch)
+    verify(batch.contains("\"2.5\"^^xsd:decimal"), batch)
+    richmond := batch.index("\"Richmond\"^^xsd:string")
+    norfolk  := batch.index("\"Norfolk\"^^xsd:string")
+    verify(richmond != null && norfolk != null && richmond < norfolk, batch)
+  }
+
+  Void testUnsupportedListItemTypesFailClosed()
+  {
+    try
+    {
+      export(Str<|Color : Enum { red }
+                   Foo : Dict { colors: List <of:Color> }|>)
+      fail("Expected unsupported enum list item")
+    }
+    catch (UnsupportedErr err)
+    {
+      verify(err.msg.contains("Foo.colors: enum item type"), err.msg)
+      verify(err.msg.endsWith("::Color"), err.msg)
+    }
+
+    try
+    {
+      export(Str<|Foo : Dict { refs: List <of:Ref> }|>)
+      fail("Expected unsupported reference list item")
+    }
+    catch (UnsupportedErr err)
+    {
+      verify(err.msg.contains("Foo.refs: reference item type sys::Ref"), err.msg)
+    }
+  }
+
   private Str export(Str src)
   {
     ns  := createNamespace(["sys"])

--- a/src/test/testXeto/fan/RdfExportTest.fan
+++ b/src/test/testXeto/fan/RdfExportTest.fan
@@ -141,6 +141,117 @@ class RdfExportTest : AbstractXetoTest
     }
   }
 
+  Void testStructuredValueShapes()
+  {
+    rdf := export(
+      Str<|Suit : Enum {
+               clubs    <key:"Clubs">
+               diamonds <key:"Diamonds">
+             }
+
+             Site : Dict
+             Related : Dict
+             Address : Dict { city: Str }
+
+             Equip : Dict {
+               suit: Suit
+               siteRef: Ref<of:Site>
+               related: MultiRef?<of:Related>
+               address: Address
+             }|>)
+
+    suit := propertyShape(rdf, "Equip.suit")
+    verify(suit.contains("sh:datatype xsd:string ;"), suit)
+    verify(suit.contains("sh:in (\"Clubs\"^^xsd:string \"Diamonds\"^^xsd:string) ;"), suit)
+    verifyFalse(rdf.contains("temp:Suit.clubs"), rdf)
+    suitClass := resourceBlock(rdf, "temp:Suit")
+    verifyFalse(suitClass.contains("a sh:NodeShape"), suitClass)
+
+    siteRef := propertyShape(rdf, "Equip.siteRef")
+    verify(siteRef.contains("sh:nodeKind sh:IRI ;"), siteRef)
+    verify(siteRef.contains("sh:class temp:Site ;"), siteRef)
+    verify(siteRef.contains("sh:minCount 1 ;"), siteRef)
+    verify(siteRef.contains("sh:maxCount 1 ;"), siteRef)
+
+    related := propertyShape(rdf, "Equip.related")
+    verify(related.contains("sh:nodeKind sh:IRI ;"), related)
+    verify(related.contains("sh:class temp:Related ;"), related)
+    verifyFalse(related.contains("sh:minCount"), related)
+    verifyFalse(related.contains("sh:maxCount"), related)
+
+    address := propertyShape(rdf, "Equip.address")
+    verify(address.contains("sh:node temp:Address ;"), address)
+    verify(address.contains("sh:minCount 1 ;"), address)
+    verify(address.contains("sh:maxCount 1 ;"), address)
+  }
+
+  Void testStructuredInstances()
+  {
+    rdf := export(
+      Str<|Suit : Enum { clubs <key:"Clubs"> }
+
+             Site : Dict
+             Related : Dict
+             Address : Dict { city: Str }
+
+             Equip : Dict {
+               dis: Str
+               count: Int
+               enabled: Bool
+               commissioned: Date
+               suit: Suit
+               siteRef: Ref<of:Site>
+               related: MultiRef?<of:Related>
+               address: Address
+               equip
+             }
+
+             Person : Dict { address: Address }
+
+             @site1: Site {}
+             @related1: Related {}
+             @related2: Related {}
+
+             @equip1: Equip {
+               dis: "AHU-1"
+               count: 7
+               enabled: "true"
+               commissioned: 2026-08-11
+               suit: "Clubs"
+               siteRef: @site1
+               related: MultiRef { @related1, @related2 }
+               address: Address { city: "Richmond" }
+               nickname: "Air handler"
+               imported
+             }
+
+             @person1: Person {
+               address @address1: Address { city: "Norfolk" }
+             }|>)
+
+    equip := instanceBlock(rdf, "equip1")
+    verify(equip.contains("a sys:Entity, temp:Equip ;"), equip)
+    verify(equip.contains("temp:Equip.dis \"AHU-1\"^^xsd:string ;"), equip)
+    verify(equip.contains("temp:Equip.count \"7\"^^xsd:integer ;"), equip)
+    verify(equip.contains("temp:Equip.enabled \"true\"^^xsd:boolean ;"), equip)
+    verify(equip.contains("temp:Equip.commissioned \"2026-08-11\"^^xsd:date ;"), equip)
+    verify(equip.contains("temp:Equip.suit \"Clubs\"^^xsd:string ;"), equip)
+    verify(equip.contains("temp:Equip.siteRef temp:site1 ;"), equip)
+    verifyEq(countMatches(equip, "temp:Equip.related "), 2)
+    verify(equip.contains("sys:hasMarker temp:Equip.equip ;"), equip)
+    verify(equip.contains("temp:Equip.address [\n    a temp:Address ;"), equip)
+    verify(equip.contains("temp:Address.city \"Richmond\"^^xsd:string ;"), equip)
+    verify(equip.contains("temp:Equip.nickname \"Air handler\"^^xsd:string ;"), equip)
+    verify(equip.contains("sys:hasMarker temp:Equip.imported ;"), equip)
+    verifyFalse(equip.contains("rdfs:label"), equip)
+
+    person := instanceBlock(rdf, "person1")
+    verify(person.contains("temp:Person.address temp:address1 ;"), person)
+    address := instanceBlock(rdf, "address1")
+    verify(address.contains("a sys:Entity, temp:Address ;"), address)
+    verify(address.contains("temp:Address.city \"Norfolk\"^^xsd:string ;"), address)
+  }
+
   private Str export(Str src)
   {
     ns  := createNamespace(["sys"])
@@ -159,6 +270,24 @@ class RdfExportTest : AbstractXetoTest
     end := rdf.index(close, start)
     if (end == null) throw Err("Unterminated property shape for ${property}")
     return rdf[start..<(end + close.size)]
+  }
+
+  private Str instanceBlock(Str rdf, Str id)
+  {
+    start := rdf.index("temp:${id}\n")
+    if (start == null) throw Err("Missing instance ${id}")
+    end := rdf.index("\n.\n", start)
+    if (end == null) throw Err("Unterminated instance ${id}")
+    return rdf[start..<(end + 3)]
+  }
+
+  private Str resourceBlock(Str rdf, Str resource)
+  {
+    start := rdf.index("${resource}\n")
+    if (start == null) throw Err("Missing resource ${resource}")
+    end := rdf.index("\n.\n", start)
+    if (end == null) throw Err("Unterminated resource ${resource}")
+    return rdf[start..<(end + 3)]
   }
 
   private Int countMatches(Str source, Str match)

--- a/src/tool/xetoTools/fan/ExportCmd.fan
+++ b/src/tool/xetoTools/fan/ExportCmd.fan
@@ -149,6 +149,7 @@ internal abstract class ExportCmd : XetoCmd
     {
       depends[t.lib.name] = t.depend
     }
+    supportLibs.each |name| { depends[name] = LibDepend(name) }
 
     // solve dependencies
     versions := env.repo.resolveDepends(depends.vals)
@@ -224,6 +225,9 @@ internal abstract class ExportCmd : XetoCmd
 
   abstract Exporter initExporter(Namespace ns, OutStream out)
 
+  ** Additional libraries required by an export format itself.
+  virtual Str[] supportLibs() { Str#.emptyList }
+
   abstract Str toFileName(ExportTarget t)
 }
 
@@ -245,4 +249,3 @@ internal const class ExportTarget
 
   override Str toStr() { specName == null ? lib.toStr : "$lib::$specName" }
 }
-

--- a/src/tool/xetoTools/fan/ExportJson.fan
+++ b/src/tool/xetoTools/fan/ExportJson.fan
@@ -21,6 +21,9 @@ internal class ExportJson : ExportCmd
   @Opt { aliases=["e"]; help = "Generate inherited effective meta/slots (default is own)" }
   Bool effective
 
+  @Opt { help = "Instance scalar boxing: none, auto, or all (default none)" }
+  Str box := "none"
+
   override Int usage(OutStream out := Env.cur.out)
   {
     super.usage(out)
@@ -32,6 +35,7 @@ internal class ExportJson : ExportCmd
   {
     opts := Str:Obj[:]
     if (effective) opts["effective"] = Marker.val
+    opts["box"] = box
     return JsonExporter(ns, out, Etc.makeDict(opts))
   }
 
@@ -40,4 +44,3 @@ internal class ExportJson : ExportCmd
     t.toStr + ".json"
   }
 }
-

--- a/src/tool/xetoTools/fan/ExportRdf.fan
+++ b/src/tool/xetoTools/fan/ExportRdf.fan
@@ -13,6 +13,12 @@ using haystack
 
 internal class ExportRdf : ExportCmd
 {
+  @Opt { help = "Export native instances without schema and ontology triples" }
+  Bool instancesOnly
+
+  @Opt { help = "Export schema and ontology triples without native instances" }
+  Bool schemaOnly
+
   override Str cmdName() { "export-rdf" }
 
   override Str summary() { "Export Xeto to RDF" }
@@ -22,6 +28,8 @@ internal class ExportRdf : ExportCmd
   override Exporter initExporter(Namespace ns, OutStream out)
   {
     opts := Str:Obj[:]
+    if (instancesOnly) opts["instancesOnly"] = Marker.val
+    if (schemaOnly) opts["schemaOnly"] = Marker.val
     return RdfExporter(ns, out, Etc.makeDict(opts))
   }
 

--- a/src/tool/xetoTools/fan/ExportRdf.fan
+++ b/src/tool/xetoTools/fan/ExportRdf.fan
@@ -17,6 +17,8 @@ internal class ExportRdf : ExportCmd
 
   override Str summary() { "Export Xeto to RDF" }
 
+  override Str[] supportLibs() { ["sys.rdf"] }
+
   override Exporter initExporter(Namespace ns, OutStream out)
   {
     opts := Str:Obj[:]
@@ -28,4 +30,3 @@ internal class ExportRdf : ExportCmd
     t.toStr + ".ttl"
   }
 }
-


### PR DESCRIPTION
This completes Haxall’s RDF export for the supported Xeto mapping profile.

The exporter now produces:

- RDF vocabulary for Xeto specs and slots
- SHACL constraints for supported scalar, marker, enum, reference, nested,
  Choice, list, Query, global, mixin, intersection, and union constructs
- RDF instance data from native compiled Xeto instances
- versioned IRIs based on the concrete libraries selected by the active namespace
- QUDT references for reviewed Xeto units and quantity kinds

Unsupported or ambiguous mappings fail with targeted errors instead of silently
producing incomplete RDF.

## Supporting changes outside `RdfExporter`

A few supporting changes were required outside the exporter itself:

- `RdfQudtMappings` loads and validates the canonical mappings packaged by
  `sys.rdf`. RDF export automatically includes `sys.rdf` in its namespace.
- `export-rdf` adds `-schemaOnly` and `-instancesOnly` options so schema and
  native instance projections can be tested or consumed independently.
- `JsonExporter` preserves global declaration identity needed by downstream
  schema consumers.
- `JsonExporter` also supports opt-in scalar boxing for lossless transport of
  compiled instance values. Its existing default JSON output remains unchanged.

## Validation

Beyond running focused tests, validated via xeto-bridge over the entire normalized
set of `ph` demo triples (~8000).