### PR TITLE
complete RDF schema and instance export

### DIFF
--- a/src/core/xetom/fan/export/RdfExporter.fan
+++ b/src/core/xetom/fan/export/RdfExporter.fan
@@ -12,10 +12,6 @@ using haystack
 **
 ** RDF Turtle Exporter
 **
-** TODO
-**   - list and dict slots not supported
-**   - query constraints not implemented
-**
 @Js
 class RdfExporter : Exporter
 {
@@ -26,6 +22,10 @@ class RdfExporter : Exporter
 
   new make(MNamespace ns, OutStream out, Dict opts) : super(ns, out, opts)
   {
+    this.instancesOnly = opts.has("instancesOnly")
+    this.schemaOnly = opts.has("schemaOnly")
+    if (instancesOnly && schemaOnly)
+      throw ArgErr("instancesOnly and schemaOnly are mutually exclusive")
   }
 
 //////////////////////////////////////////////////////////////////////////
@@ -44,10 +44,19 @@ class RdfExporter : Exporter
 
   override This lib(Lib lib)
   {
+    this.curLib = lib
+    this.instanceMemberSpecs.clear
     this.isSys = lib.name == "sys"
-    types := lib.types.list
-
+    validateNamespaceVersions(lib)
     prefixDefs(lib)
+    if (instancesOnly)
+    {
+      lib.instances.each |x| { instance(x) }
+      return this
+    }
+
+    validateSealedNamespace(lib)
+    types := lib.types.list
     ontologyDef(lib)
 
     if (isSys)
@@ -56,9 +65,32 @@ class RdfExporter : Exporter
       types = types.dup.moveTo(types.find { it.name == "Obj" }, 0)
     }
 
-    types.each |x| { if (!XetoUtil.isAutoName(x.name)) cls(x) }
-    lib.mixins.each |x| { if (!XetoUtil.isAutoName(x.name)) cls(x) }
-    lib.instances.each |x| { instance(x) }
+    types.each |x| { if (!XetoUtil.isAutoName(x.name)) cls(ns.specx(x)) }
+
+    // A mixin contributes to its target's effective shape; it is not an RDF
+    // class of its own. Emit each affected target once with all namespace
+    // mixins applied, while its contributed slots retain their own qnames.
+    mixinTargets := Str:Spec[][:]
+    lib.mixins.each |contribution|
+    {
+      target := contribution.base
+      if (target == null)
+        throw UnsupportedErr("Mixin contribution ${contribution.qname} has no target spec")
+
+      // +Spec declares metadata rather than application data. Known metadata
+      // is consumed by its mapping rule; metadata without a rule is omitted.
+      if (target.qname == "sys::Spec") return
+
+      mixinTargets.getOrAdd(target.qname) { Spec[,] }.add(contribution)
+    }
+    mixinTargets.each |contributions, targetQname|
+    {
+      target := ns.spec(targetQname, false)
+      if (target == null) target = contributions.first.base
+      if (target == null) throw UnsupportedErr("Mixin target not found: ${targetQname}")
+      mixinShape(target, contributions)
+    }
+    if (!schemaOnly) lib.instances.each |x| { instance(x) }
     return this
   }
 
@@ -67,7 +99,7 @@ class RdfExporter : Exporter
     this.isSys = spec.lib.name == "sys"
     if (spec.isType) return cls(spec)
     if (spec.isGlobal) return global(spec)
-    throw Err(spec.name)
+    throw UnsupportedErr("RDF export target is neither a type nor a global: ${spec.qname}")
   }
 
 //////////////////////////////////////////////////////////////////////////
@@ -84,8 +116,17 @@ class RdfExporter : Exporter
     w("@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .").nl
     w("@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .").nl
     w("@prefix sh: <http://www.w3.org/ns/shacl#> .").nl
-    lib.depends.each |x| { prefixDef(ns.lib(x.name)) }
-    prefixDef(lib)
+    w("@prefix skos: <http://www.w3.org/2004/02/skos/core#> .").nl
+    w("@prefix qudt: <http://qudt.org/schema/qudt/> .").nl
+    w("@prefix unit: <http://qudt.org/vocab/unit/> .").nl
+    w("@prefix currency: <http://qudt.org/vocab/currency/> .").nl
+    w("@prefix quantitykind: <http://qudt.org/vocab/quantitykind/> .").nl
+    // Effective shapes may contain slots contributed by any active namespace
+    // library, including mixins whose owner is not a direct dependency.
+    // Declare every active prefix so all emitted qnames are valid Turtle.
+    libs := ns.libs.dup.sort |a, b| { a.name <=> b.name }
+    libs.each |x| { prefixDef(x) }
+    if (!libs.any |x| { x.name == lib.name }) prefixDef(lib)
     nl
   }
 
@@ -106,7 +147,7 @@ class RdfExporter : Exporter
       lib.depends.each |x, i|
       {
         if (i > 0) w(",").nl.w(Str.spaces(12))
-        w("<").w(libUri(ns.lib(x.name))).w(">")
+        w("<").w(libUri(requireLibrary(x.name))).w(">")
       }
     }
     nl.w(".").nl
@@ -150,7 +191,9 @@ class RdfExporter : Exporter
       if (s.isMarker) markers.add(s)
       else props.add(s)
     }
-    hasShape := !props.isEmpty || markers.any |s| { !s.isMaybe }
+    isAbstract := x.meta.has("abstract")
+    hasShape := !x.isEnum &&
+                (isAbstract || (x.isCompound && x.isOr) || !props.isEmpty || markers.any |s| { !s.isMaybe })
 
     qname(x.qname).nl
 
@@ -158,23 +201,35 @@ class RdfExporter : Exporter
     w("  a sys:Class ;").nl
     w("  a rdfs:Class ;").nl
 
-    // Choice members are instances of themselves. Other classes are SHACL
-    // shapes only when they have effective constraints to validate.
-    if (isThisInstance(x)) w("  a ").qname(x.qname).w(" ;").nl
-    else if (hasShape) w("  a sh:NodeShape ;").nl
+    // Classes with effective constraints are also SHACL node shapes.
+    if (hasShape) w("  a sh:NodeShape ;").nl
 
-    // supertype
-    if (x.base != null) w("  rdfs:subClassOf ").qname(x.base.qname).w(" ;").nl
-    else  w("  rdfs:subClassOf rdfs:Resource ;").nl
+    // Intersections are subclasses of every member. Unions reverse that
+    // relationship below so each member is a subclass of the union.
+    if (x.isCompound && x.isAnd)
+    {
+      w("  rdfs:subClassOf ")
+      x.bases.each |base, i|
+      {
+        if (i > 0) w(", ")
+        qname(base.qname)
+      }
+      w(" ;").nl
+    }
+    else if (!(x.isCompound && x.isOr))
+    {
+      if (x.base != null) w("  rdfs:subClassOf ").qname(x.base.qname).w(" ;").nl
+      else  w("  rdfs:subClassOf rdfs:Resource ;").nl
+    }
 
     // label and comment properties
     labelAndDoc(x)
 
-    // expand enum items as self-referential class/instances
+    // Enum values are RDF string literals constrained by sh:in; they are not
+    // vocabulary individuals of their own.
     if (x.isEnum)
     {
       w(".").nl
-      enum(x)
       return this
     }
 
@@ -184,6 +239,23 @@ class RdfExporter : Exporter
     if (hasShape)
     {
       w("  sh:targetClass ").qname(x.qname).w(" ;").nl
+      if (x.isCompound && x.isOr)
+      {
+        w("  sh:or (").nl
+        x.bases.each |member| { w("    [ sh:class ").qname(member.qname).w(" ]").nl }
+        w("  ) ;").nl
+      }
+      if (isAbstract)
+      {
+        // Concrete descendants remain valid; reject only an instance whose
+        // rdf:type directly names this abstract spec.
+        w("  sh:not [").nl
+        w("    sh:property [").nl
+        w("      sh:path rdf:type ;").nl
+        w("      sh:hasValue ").qname(x.qname).nl
+        w("    ]").nl
+        w("  ] ;").nl
+      }
       props.each |s| { propShape(s) }
       markers.each |s| { if (!s.isMaybe) markerShape(s) }
     }
@@ -195,19 +267,51 @@ class RdfExporter : Exporter
     {
       slot(s)
     }
+    x.globalsOwn.each |g| { global(g) }
+
+    if (x.isCompound && x.isOr)
+    {
+      x.bases.each |member|
+      {
+        qname(member.qname).w(" rdfs:subClassOf ").qname(x.qname).w(" .").nl
+      }
+    }
 
     return this
   }
 
-  private Bool isThisInstance(Spec x)
+  ** Emit only this library's contribution to a dependency-owned target. The
+  ** dependency graph owns the target class and its original constraints;
+  ** this graph adds a SHACL shape with contributor-owned properties.
+  private Void mixinShape(Spec target, Spec[] contributions)
   {
-    if (x.isChoice)
+    props   := Spec[,]
+    markers := Spec[,]
+    contributions.each |contribution|
     {
-      // Choice and first level of Choice inheritance are not
-      if (x.base.lib.name == "sys") return false
-      return true
+      contribution.slotsOwn.each |slot|
+      {
+        if (slot.isMarker) markers.add(slot)
+        else props.add(slot)
+      }
     }
-    return false
+
+    if (!props.isEmpty || markers.any |slot| { !slot.isMaybe })
+    {
+      qname(target.qname).nl
+      w("  a sh:NodeShape ;").nl
+      markers.each |slot| { hasMarker(slot) }
+      w("  sh:targetClass ").qname(target.qname).w(" ;").nl
+      props.each |slot| { propShape(slot) }
+      markers.each |slot| { if (!slot.isMaybe) markerShape(slot) }
+      w(".").nl
+    }
+
+    contributions.each |contribution|
+    {
+      contribution.slotsOwn.each |slot| { this.slot(slot) }
+      contribution.globalsOwn.each |globalSlot| { global(globalSlot) }
+    }
   }
 
   private Void hasMarker(Spec slot)
@@ -227,6 +331,27 @@ class RdfExporter : Exporter
 
   private Void propShape(Spec slot)
   {
+    type := slot.type
+    if (type.isThis || ((type.isRef || type.isMultiRef) && slot.of(false)?.isThis == true))
+      throw UnsupportedErr("RDF parent-relative This mapping not supported for ${slot.qname}")
+    if (type.isGrid)
+      throw UnsupportedErr("RDF Grid mapping not supported for ${slot.qname} of ${type.qname}")
+    if (type.qname == "sys::Collection")
+      throw UnsupportedErr("RDF Collection mapping not supported for ${slot.qname} of ${type.qname}")
+    if (type.isFunc)
+      throw UnsupportedErr("RDF Func mapping not supported for ${slot.qname} of ${type.qname}")
+    if (type.isInterface)
+      throw UnsupportedErr("RDF Interface mapping not supported for ${slot.qname} of ${type.qname}")
+    if (type.isComp)
+      throw UnsupportedErr("RDF runtime component mapping not supported for ${slot.qname} of ${type.qname}")
+
+    if (slot.isQuery)
+    {
+      required := slot.slotsOwn.list.find |Spec member->Bool| { !member.isMaybe }
+      if (required != null)
+        throw UnsupportedErr("RDF query body mapping not supported for required member ${required.qname}")
+    }
+
     // build constraints
     sh := Str:Obj[:]
     sh.ordered = true
@@ -234,32 +359,65 @@ class RdfExporter : Exporter
     hasMaxCount := true
 
     // value type
-    type := slot.type
-    isLiteral := (type.isScalar && !type.isRef) || type.qname == "sys::TimeZone"
+    isQuantityValue := isQuantityValueSlot(slot)
+    isLiteral := ((type.isScalar && !type.isRef) || type.qname == "sys::TimeZone") &&
+                 !isQuantityValue && type.qname != "sys::Unit" &&
+                 type.qname != "sys::UnitQuantity"
     datatype := isLiteral ? scalarDatatype(type) : null
-    if (isLiteral)
+    if (slot.isQuery)
+    {
+      of := slot.of(false)
+      if (of != null) sh["class"] = qnameToUri(of.qname)
+      hasMinCount = false
+      hasMaxCount = false
+    }
+    else if (type.qname == "sys::Unit")
+    {
+      sh["class"] = "qudt:Unit"
+    }
+    else if (isQuantityValue)
+    {
+      // The scalar's datatype and range move to qudt:numericValue below.
+    }
+    else if (isLiteral)
     {
       sh["datatype"] = datatype
     }
     else if (type.isRef || type.isMultiRef)
     {
       of := slot.of(false)?.qname ?: "sys::Entity"
+      sh["nodeKind"] = "sh:IRI"
       sh["class"] = qnameToUri(of)
       if (type.isMultiRef) hasMaxCount = false
     }
     else if (type.isEnum)
     {
-      sh["class"] = qnameToUri(type.qname)
+      if (type.qname == "sys::UnitQuantity")
+        throw UnsupportedErr("RDF UnitQuantity mapping not supported for ${slot.qname} of ${type.qname}")
+      sh["datatype"] = "xsd:string"
     }
     else if (type.isChoice)
     {
-      sh["class"] = qnameToUri(type.qname)
-      if (slot.meta.has("multiChoice")) hasMaxCount = false
+      choice := ns.choice(slot)
+      hasMinCount = !choice.isMaybe
+      hasMaxCount = !choice.isMultiChoice
+    }
+    else if (type.isList)
+    {
+      // List item and size constraints are emitted below on the RDF
+      // collection path. The outer slot remains one list value.
+    }
+    else if (type.isDict)
+    {
+      sh["node"] = qnameToUri(type.qname)
+    }
+    else if (type.qname == "sys::Obj")
+    {
+      // Obj deliberately constrains only cardinality.
     }
     else
     {
-      // Preserve the existing fallback for constructs handled by later slices.
-      sh["datatype"] = "xsd:string"
+      throw UnsupportedErr("RDF slot type mapping not supported for ${slot.qname} of ${type.qname}")
     }
 
     // cardinality minCount/maxCount
@@ -268,31 +426,363 @@ class RdfExporter : Exporter
 
     // write property shape
     w("  sh:property [").nl
-    w("    sh:path ").qname(slot.qname).w(" ;").nl
+    w("    sh:path ")
+    if (slot.isQuery) queryPath(slot)
+    else qname(slot.qname)
+    w(" ;").nl
     sh.each |v, n| { w("    sh:").w(n).w(" ").w(v).w(" ;").nl }
+    if (type.isEnum && type.qname != "sys::Unit" &&
+        type.qname != "sys::UnitQuantity" && type.qname != "sys::TimeZone")
+      enumConstraint(type)
+    if (type.isChoice) choiceConstraint(slot)
+    if (type.isList) listConstraint(slot)
+    if (type.qname == "sys::Unit")
+    {
+      quantity := metaQuantity(slot)
+      if (quantity != null) quantityKindConstraint(quantity, "    ")
+    }
+    if (isQuantityValue) quantityValueConstraint(slot)
     if (datatype != null) scalarConstraints(slot, datatype)
     w("  ] ;").nl
+  }
+
+  ** Write the computed SHACL property path for a query slot. Query metadata
+  ** is resolved in the library that owns the declaration, which matters for
+  ** slots contributed to another library's type by a mixin.
+  private Void queryPath(Spec query)
+  {
+    viaVal := query.meta["via"]
+    inverseVal := query.meta["inverse"]
+    if (viaVal != null && inverseVal != null)
+      throw UnsupportedErr("RDF query ${query.qname} cannot declare both via and inverse")
+
+    if (viaVal != null)
+    {
+      via := viaVal as Str
+        ?: throw UnsupportedErr("Invalid via metadata for ${query.qname}: ${viaVal.typeof}")
+      writeViaPath(query, via, false)
+      return
+    }
+
+    if (inverseVal != null)
+    {
+      inverse := inverseVal as Str
+        ?: throw UnsupportedErr("Invalid inverse metadata for ${query.qname}: ${inverseVal.typeof}")
+      validateQueryPath(query, inverse, false)
+      inverseQname := resolveQueryName(query, inverse)
+      inverseQuery := resolveSpec(inverseQname)
+      if (inverseQuery != null && inverseQuery.isQuery)
+      {
+        inverseViaVal := inverseQuery.meta["via"]
+        inverseVia := inverseViaVal as Str
+        if (inverseViaVal != null && inverseVia == null)
+          throw UnsupportedErr("Invalid via metadata for ${inverseQuery.qname}: ${inverseViaVal.typeof}")
+        if (inverseVia == null)
+          throw UnsupportedErr("Inverse query ${query.qname} must reference a via query: ${inverseQname}")
+        writeViaPath(inverseQuery, inverseVia, true)
+      }
+      else
+      {
+        w("[ sh:inversePath ").qname(inverseQname).w(" ]")
+      }
+      return
+    }
+
+    // A plain query is still computed and has no cardinality, but its RDF
+    // predicate is the ordinary declared slot property.
+    qname(query.qname)
+  }
+
+  private Void writeViaPath(Spec query, Str source, Bool inverse)
+  {
+    validateQueryPath(query, source, true)
+
+    quantifier := ""
+    if (source.endsWith("+") || source.endsWith("*"))
+    {
+      quantifier = source[-1].toChar
+      source = source[0..-2]
+    }
+
+    property := resolveQueryName(query, source)
+    if (!quantifier.isEmpty)
+      w(quantifier == "+" ? "[ sh:oneOrMorePath " : "[ sh:zeroOrMorePath ")
+    if (inverse) w("[ sh:inversePath ")
+    qname(property)
+    if (inverse) w(" ]")
+    if (!quantifier.isEmpty) w(" ]")
+  }
+
+  private Void validateQueryPath(Spec query, Str source, Bool allowQuantifier)
+  {
+    if (source.isEmpty)
+      throw UnsupportedErr("Empty query path for ${query.qname}")
+
+    path := source
+    if (allowQuantifier && (path.endsWith("+") || path.endsWith("*")))
+    {
+      path = path[0..-2]
+      if (path.isEmpty)
+        throw UnsupportedErr("Empty query path for ${query.qname}")
+    }
+
+    if (path.contains("+") || path.contains("*") || !queryPathRef.matches(path))
+      throw UnsupportedErr("Invalid query path for ${query.qname}: ${source}")
+  }
+
+  ** Resolve an unqualified path relative to the query declaration. A
+  ** Spec.slot path is relative to the declaration's library; a fully
+  ** qualified lib::Spec.slot path retains its explicit owner.
+  private Str resolveQueryName(Spec query, Str name)
+  {
+    if (name.contains("::")) return name
+    if (name.contains(".")) return "${query.lib.name}::${name}"
+    parent := query.parent
+      ?: throw UnsupportedErr("Query ${query.qname} has no declaring parent")
+    return "${parent.qname}.${name}"
+  }
+
+  ** Namespace lookup does not include a temporary library until installed,
+  ** so fall back to the currently exported library for its own query slots.
+  private Spec? resolveSpec(Str qname)
+  {
+    found := ns.spec(qname, false)
+    if (found != null) return found
+
+    lib := curLib
+    if (lib == null || !qname.startsWith("${lib.name}::")) return null
+    local := qname[qname.index("::") + 2..-1]
+    dot := local.index(".")
+    if (dot == null) return lib.spec(local, false)
+    parent := lib.spec(local[0..<dot], false)
+    if (parent == null) return null
+    return parent.slot(local[dot + 1..-1], false)
+  }
+
+  private Bool isQuantityValueSlot(Spec slot)
+  {
+    slot.type.qname == "sys::Number" &&
+      (slot.meta["unit"] != null || slot.meta["quantity"] != null)
+  }
+
+  private Void quantityValueConstraint(Spec slot)
+  {
+    w("    sh:node [").nl
+    w("      sh:class qudt:QuantityValue ;").nl
+    w("      sh:property [").nl
+    w("        sh:path qudt:numericValue ;").nl
+    w("        sh:datatype xsd:double ;").nl
+
+    minVal := quantityNumericMeta(slot, "minVal")
+    if (minVal != null) w("        sh:minInclusive ").literal(minVal).w("^^xsd:double ;").nl
+    maxVal := quantityNumericMeta(slot, "maxVal")
+    if (maxVal != null) w("        sh:maxInclusive ").literal(maxVal).w("^^xsd:double ;").nl
+    if (slot.meta.has("invariant"))
+    {
+      val := quantityNumericMeta(slot, "val", false)
+      if (val == null)
+        throw UnsupportedErr("Invariant quantity slot ${slot.qname} is missing val metadata")
+      w("        sh:hasValue ").literal(val).w("^^xsd:double ;").nl
+    }
+    w("        sh:minCount 1 ;").nl
+    w("        sh:maxCount 1 ;").nl
+    w("      ] ;").nl
+
+    w("      sh:property [").nl
+    w("        sh:path qudt:unit ;").nl
+    w("        sh:class qudt:Unit ;").nl
+    unit := metaUnit(slot)
+    if (unit != null)
+      w("        sh:hasValue ").w(qudt.unit(unit)).w(" ;").nl
+    quantity := metaQuantity(slot)
+    if (quantity != null) quantityKindConstraint(quantity, "        ")
+    w("        sh:minCount 1 ;").nl
+    w("        sh:maxCount 1 ;").nl
+    w("      ]").nl
+    w("    ] ;").nl
+  }
+
+  private Void quantityKindConstraint(UnitQuantity quantity, Str indent)
+  {
+    targets := qudt.quantity(quantity)
+    if (targets.size == 1)
+    {
+      w(indent).w("sh:node [ sh:property [ sh:path ( qudt:hasQuantityKind [ sh:zeroOrMorePath skos:broader ] ) ; sh:hasValue quantitykind:").w(targets.first).w(" ] ] ;").nl
+      return
+    }
+
+    w(indent).w("sh:node [ sh:or (").nl
+    targets.each |target|
+    {
+      w(indent).w("  [ sh:property [ sh:path ( qudt:hasQuantityKind [ sh:zeroOrMorePath skos:broader ] ) ; sh:hasValue quantitykind:").w(target).w(" ] ]").nl
+    }
+    w(indent).w(") ] ;").nl
+  }
+
+  private Unit? metaUnit(Spec slot)
+  {
+    val := slot.meta["unit"]
+    if (val == null) return null
+    unit := val as Unit
+    if (unit != null) return unit
+    if (val is Str) return Unit.fromStr(val)
+    throw UnsupportedErr("Invalid unit metadata for ${slot.qname}: ${val.typeof}")
+  }
+
+  private UnitQuantity? metaQuantity(Spec slot)
+  {
+    val := slot.meta["quantity"]
+    if (val == null) return null
+    quantity := val as UnitQuantity
+    if (quantity != null) return quantity
+    if (val is Str) return UnitQuantity.fromStr(val)
+    throw UnsupportedErr("Invalid quantity metadata for ${slot.qname}: ${val.typeof}")
+  }
+
+  private Void choiceConstraint(Spec slot)
+  {
+    // The RDF specification constrains a choice slot to the member IRIs
+    // visible in the active namespace, rather than to marker values.
+    members := choiceMembers(slot)
+    if (members.isEmpty)
+      throw UnsupportedErr("RDF choice ${slot.qname} has no members in the active namespace")
+    w("    sh:in (")
+    members.each |member, i|
+    {
+      if (i > 0) w(" ")
+      qname(member.qname)
+    }
+    w(") ;").nl
+  }
+
+  private Spec[] choiceMembers(Spec slot)
+  {
+    // The declared slot type defines the selected branch. For an intermediate
+    // Choice this includes the marker-bearing type itself and its descendants,
+    // but excludes sibling branches under the root Choice.
+    choiceType := slot.type
+
+    // Namespace types cover installed dependency libraries. curLib is merged
+    // explicitly because temporary or currently-exported libraries are not
+    // necessarily installed in Namespace.eachType yet. Key by qname so a
+    // library visible through both paths contributes each candidate once.
+    candidates := Str:Spec[:]
+    ns.eachType |candidate| { candidates[candidate.qname] = candidate }
+    curLib?.types?.each |candidate| { candidates[candidate.qname] = candidate }
+
+    members := Spec[,]
+    candidates.each |candidate|
+    {
+      if (!candidate.isChoice) return
+      if (!candidate.isa(choiceType)) return
+      if (!candidate.slots.list.any |Spec memberSlot->Bool| { memberSlot.isMarker }) return
+      members.add(candidate)
+    }
+    members.sort |a, b| { a.qname <=> b.qname }
+    return members
+  }
+
+  private Void listConstraint(Spec slot)
+  {
+    of := slot.of(false)
+    validateListItemType(slot, of)
+
+    minSize := intMeta(slot, "minSize")
+    if (slot.meta.has("nonEmpty") && (minSize == null || minSize < 1)) minSize = 1
+    maxSize := intMeta(slot, "maxSize")
+    if (of == null && minSize == null && maxSize == null) return
+
+    // A Xeto list is one slot value represented by an RDF collection. Validate
+    // item values through rdf:first, but count rdf:rest nodes for size so equal
+    // item values do not collapse under SHACL property-path set semantics.
+    w("    sh:node [").nl
+    if (of != null)
+    {
+      w("      sh:property [").nl
+      w("        sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;").nl
+      if (of.isScalar)
+        w("        sh:datatype ").w(scalarDatatype(of)).w(" ;").nl
+      else if (of.isDict)
+        w("        sh:class ").qname(of.qname).w(" ;").nl
+      w("      ] ;").nl
+    }
+    if (minSize != null || maxSize != null)
+    {
+      w("      sh:property [").nl
+      w("        sh:path [ sh:zeroOrMorePath rdf:rest ] ;").nl
+      if (minSize != null) w("        sh:minCount ").w(listNodeCount(slot, "minSize", minSize)).w(" ;").nl
+      if (maxSize != null) w("        sh:maxCount ").w(listNodeCount(slot, "maxSize", maxSize)).w(" ;").nl
+      w("      ] ;").nl
+    }
+    w("    ] ;").nl
+  }
+
+  private Int listNodeCount(Spec slot, Str name, Int size)
+  {
+    if (size == Int.maxVal)
+      throw UnsupportedErr("${name} is too large for RDF list-node counting on ${slot.qname}")
+    return size + 1
+  }
+
+  private Void validateListItemType(Spec slot, Spec? of)
+  {
+    if (of == null) return
+
+    // The current public mapping defines scalar and direct-dictionary items.
+    // Deferred forms fail closed instead of being omitted or stringified.
+    kind := "item type ${of.qname}"
+    if (of.isChoice) kind = "choice item type ${of.qname}"
+    else if (of.qname == "sys::Unit") kind = "unit item type ${of.qname}"
+    else if (of.isEnum) kind = "enum item type ${of.qname}"
+    else if (of.isRef || of.isMultiRef) kind = "reference item type ${of.qname}"
+    else if (of.isList) kind = "nested-list item type ${of.qname}"
+    else if (of.isScalar || of.isDict) return
+    throw UnsupportedErr("RDF list mapping not supported for ${slot.qname}: ${kind}")
+  }
+
+  private Void enumConstraint(Spec type)
+  {
+    w("    sh:in (")
+    type.enum.keys.sort.each |key, i|
+    {
+      if (i > 0) w(" ")
+      literal(key).w("^^xsd:string")
+    }
+    w(") ;").nl
   }
 
   private Void scalarConstraints(Spec slot, Str datatype)
   {
     meta := slot.meta
 
-    minVal := numericMeta(meta["minVal"])
-    if (minVal != null) w("    sh:minInclusive ").w(minVal).w(" ;").nl
+    minVal := numericMeta(slot, "minVal", datatype)
+    if (minVal != null)
+    {
+      w("    sh:minInclusive ")
+      if (datatype == "xsd:double") literal(minVal).w("^^xsd:double")
+      else w(minVal)
+      w(" ;").nl
+    }
 
-    maxVal := numericMeta(meta["maxVal"])
-    if (maxVal != null) w("    sh:maxInclusive ").w(maxVal).w(" ;").nl
+    maxVal := numericMeta(slot, "maxVal", datatype)
+    if (maxVal != null)
+    {
+      w("    sh:maxInclusive ")
+      if (datatype == "xsd:double") literal(maxVal).w("^^xsd:double")
+      else w(maxVal)
+      w(" ;").nl
+    }
 
-    minSize := intMeta(meta["minSize"])
+    minSize := intMeta(slot, "minSize")
     if (minSize != null) w("    sh:minLength ").w(minSize).w(" ;").nl
 
-    maxSize := intMeta(meta["maxSize"])
+    maxSize := intMeta(slot, "maxSize")
     if (maxSize != null) w("    sh:maxLength ").w(maxSize).w(" ;").nl
 
-    pattern := scalarPattern(slot)
-    if (pattern != null)
+    scalarPatterns(slot, datatype).each |pattern|
+    {
       w("    sh:pattern ").literal(pattern).w(" ;").nl
+    }
 
     if (meta.has("nonEmpty"))
       w("    sh:pattern ").literal("\\S").w(" ;").nl
@@ -300,12 +790,11 @@ class RdfExporter : Exporter
     if (meta.has("invariant"))
     {
       val := meta["val"]
-      if (val != null)
-      {
-        w("    sh:hasValue ")
-        typedLiteral(val, datatype)
-        w(" ;").nl
-      }
+      if (val == null)
+        throw UnsupportedErr("Invariant scalar slot ${slot.qname} is missing val metadata")
+      w("    sh:hasValue ")
+      typedLiteral(val, slot.type, slot.qname)
+      w(" ;").nl
     }
   }
 
@@ -314,7 +803,8 @@ class RdfExporter : Exporter
     switch (type.qname)
     {
       case "sys::Str":      return "xsd:string"
-      case "sys::Number":   return "xsd:decimal"
+      case "sys::Number":   return "xsd:double"
+      case "sys::Float":    return "xsd:double"
       case "sys::Int":      return "xsd:integer"
       case "sys::Bool":     return "xsd:boolean"
       case "sys::Date":     return "xsd:date"
@@ -324,16 +814,44 @@ class RdfExporter : Exporter
       case "sys::TimeZone": return "xsd:string"
     }
 
-    // User-defined Scalar subtypes have string lexical values unless this
-    // profile assigns their qname a more specific datatype above.
+    // sys is a closed runtime vocabulary, so an unlisted sys scalar is
+    // unsupported. A declared non-sys Scalar is the profile's custom string
+    // datatype extension unless a more specific mapping appears above.
     if (type.isScalar && type.lib.name != "sys") return "xsd:string"
     throw UnsupportedErr("RDF scalar datatype not supported: ${type.qname}")
   }
 
-  private Str? scalarPattern(Spec slot)
+  ** Return every string pattern contributed by the custom scalar hierarchy,
+  ** followed by any slot-level refinement. Each pattern is a separate SHACL
+  ** constraint, so a value must satisfy the complete inherited contract.
+  private Str[] scalarPatterns(Spec slot, Str datatype)
   {
-    pattern := slot.meta["pattern"] as Str
-    if (pattern == null) return null
+    // Xeto's built-in numeric/date patterns describe source syntax and are
+    // not SHACL regex constraints on RDF typed literals.
+    if (datatype != "xsd:string") return Str[,]
+
+    patterns := Str[,]
+    added := Str:Bool[:]
+    chain := Spec[,]
+    seen := Str:Bool[:]
+    Spec? cur := slot.type
+    while (cur != null && cur.isScalar && cur.lib.name != "sys")
+    {
+      if (seen.containsKey(cur.qname))
+        throw UnsupportedErr("Cyclic Xeto type inheritance while resolving ${slot.type.qname}: ${cur.qname}")
+      seen[cur.qname] = true
+      chain.add(cur)
+      cur = cur.base
+    }
+    chain.reverse.each |type|
+    {
+      addScalarPattern(patterns, added, type.qname, type.meta["pattern"])
+    }
+
+    patternVal := slot.meta["pattern"]
+    if (patternVal == null) return patterns
+    pattern := patternVal as Str
+      ?: throw UnsupportedErr("Invalid pattern metadata for ${slot.qname}: ${patternVal.typeof}")
 
     // Built-in scalar patterns describe Xeto's source encoding; they are not
     // additional value constraints. Keep a slot override or a custom scalar's
@@ -341,68 +859,221 @@ class RdfExporter : Exporter
     type := slot.type
     if (isBuiltInScalar(type.qname))
     {
-      typePattern := type.meta["pattern"] as Str
-      if (pattern == typePattern) return null
+      typePatternVal := type.meta["pattern"]
+      typePattern := typePatternVal as Str
+      if (typePatternVal != null && typePattern == null)
+        throw UnsupportedErr("Invalid pattern metadata for ${type.qname}: ${typePatternVal.typeof}")
+      if (pattern == typePattern) return patterns
     }
-    return pattern
+    if (!added.containsKey(pattern))
+    {
+      added[pattern] = true
+      patterns.add(pattern)
+    }
+    return patterns
+  }
+
+  private Void addScalarPattern(Str[] patterns, Str:Bool added, Str owner, Obj? val)
+  {
+    if (val == null) return
+    pattern := val as Str
+      ?: throw UnsupportedErr("Invalid pattern metadata for ${owner}: ${val.typeof}")
+    if (added.containsKey(pattern)) return
+    added[pattern] = true
+    patterns.add(pattern)
   }
 
   private Bool isBuiltInScalar(Str qname)
   {
     qname == "sys::Str"     || qname == "sys::Number" ||
-    qname == "sys::Int"     || qname == "sys::Bool"   ||
+    qname == "sys::Float"   || qname == "sys::Int"    ||
+    qname == "sys::Bool"    ||
     qname == "sys::Date"    || qname == "sys::Time"   ||
     qname == "sys::DateTime"|| qname == "sys::Uri"    ||
     qname == "sys::TimeZone"
   }
 
-  private Str? numericMeta(Obj? val)
+  private Str? numericMeta(Spec slot, Str name, Str datatype)
   {
-    if (val is Int) return val.toStr
-    if (val is Float) return val.toStr
-    num := val as Number
-    if (num == null || num.unit != null) return null
-    return num.toStr
+    val := slot.meta[name]
+    if (val == null) return null
+    context := "${slot.qname}.${name}"
+    if (datatype == "xsd:double")
+    {
+      if (val is Int) return doubleLexical(val.toStr, context)
+      if (val is Float)
+      {
+        lexical := doubleLexical(val.toStr, context)
+        if (lexical == "NaN")
+          throw UnsupportedErr("Invalid numeric metadata for ${context}: NaN is not an ordered bound")
+        return lexical
+      }
+      num := val as Number
+      if (num == null || num.unit != null)
+        throw UnsupportedErr("Invalid numeric metadata for ${context}: ${val.typeof}")
+      lexical := doubleLexical(num.toFloat.toStr, context)
+      if (lexical == "NaN")
+        throw UnsupportedErr("Invalid numeric metadata for ${context}: NaN is not an ordered bound")
+      return lexical
+    }
+    if (datatype == "xsd:integer") return intMeta(slot, name)?.toStr
+    throw UnsupportedErr("Invalid numeric metadata datatype for ${context}: ${datatype}")
   }
 
-  private Int? intMeta(Obj? val)
+  private Str? quantityNumericMeta(Spec slot, Str name, Bool ordered := true)
   {
+    val := slot.meta[name]
+    if (val == null) return null
+    context := "${slot.qname}.${name}"
+    if (val is Int) return doubleLexical(val.toStr, context)
+    if (val is Float)
+    {
+      lexical := doubleLexical(val.toStr, context)
+      if (ordered && lexical == "NaN")
+        throw UnsupportedErr("Invalid numeric metadata for ${context}: NaN is not an ordered bound")
+      return lexical
+    }
+    num := val as Number
+    if (num == null)
+      throw UnsupportedErr("Invalid numeric metadata for ${slot.qname}.${name}: ${val.typeof}")
+    lexical := doubleLexical(num.toFloat.toStr, context)
+    if (ordered && lexical == "NaN")
+      throw UnsupportedErr("Invalid numeric metadata for ${context}: NaN is not an ordered bound")
+    return lexical
+  }
+
+  private Int? intMeta(Spec slot, Str name)
+  {
+    val := slot.meta[name]
+    if (val == null) return null
     if (val is Int) return val
     num := val as Number
-    if (num == null || num.unit != null || !num.isInt) return null
+    if (num == null)
+      throw UnsupportedErr("Invalid integer metadata for ${slot.qname}.${name}: ${val.typeof}")
+    if (num.unit != null)
+      throw UnsupportedErr("Invalid integer metadata for ${slot.qname}.${name}: unit-bearing Number")
+    if (!num.isInt)
+      throw UnsupportedErr("Invalid integer metadata for ${slot.qname}.${name}: non-integer Number")
     return num.toInt
   }
 
-  private This typedLiteral(Obj val, Str datatype)
+  ** Convert only runtime values with a defined scalar mapping. This avoids
+  ** accepting an arbitrary object merely because its `toStr` happens to look
+  ** like a legal lexical form for the requested RDF datatype.
+  private This typedLiteral(Obj val, Spec type, Str context)
   {
-    literal(val.toStr).w("^^").w(datatype)
+    datatype := scalarDatatype(type)
+    lexical := scalarLexical(val, type, context)
+    return literal(lexical).w("^^").w(datatype)
   }
 
-  private This enum(Spec x)
+  private Str scalarLexical(Obj val, Spec type, Str context)
   {
-    x.enum.each |item, key|
+    qname := type.qname
+    wrapped := val as Scalar
+    if (wrapped != null)
     {
-      uri := enumItemUri(item)
-      w(uri).nl
-      w("  a sys:Class ;").nl
-      w("  a ").w(uri).w(" ;").nl
-      w("  rdfs:label ").literal(key).w("; ").nl
-      w("  rdfs:subClassOf ").qname(x.qname).w("; ").nl
-      w(".").nl
+      if (wrapped.qname != qname)
+        throw UnsupportedErr("Expected ${qname} for ${context}, not ${wrapped.qname}")
+      val = wrapped.val
     }
-    return this
-  }
 
-  private Str enumItemUri(Spec item)
-  {
-    qnameToUri(item.qname)
+    if (qname == "sys::Str")
+      return val as Str ?: throw UnsupportedErr("Expected Str for ${context}, not ${val.typeof}")
+
+    if (type.isScalar && type.lib.name != "sys")
+    {
+      str := val as Str
+      if (str != null) return str
+      binding := type.binding
+      if (binding.isScalar && val.typeof.fits(binding.type))
+        return binding.encodeScalar(val)
+      throw UnsupportedErr("Expected ${binding.type} for ${context}, not ${val.typeof}")
+    }
+
+    if (qname == "sys::Int")
+    {
+      if (val is Int) return val.toStr
+      num := val as Number
+      if (num == null || num.unit != null || num.isSpecial || !num.isInt)
+        throw UnsupportedErr("Expected integer value for ${context}, not ${val.typeof}")
+      return num.toInt.toStr
+    }
+
+    if (qname == "sys::Number")
+    {
+      if (val is Int) return doubleLexical(val.toStr, context)
+      num := val as Number
+      if (num == null || num.unit != null)
+        throw UnsupportedErr("Expected unitless Number for ${context}, not ${val.typeof}")
+      return doubleLexical(num.toFloat.toStr, context)
+    }
+
+    if (qname == "sys::Float")
+    {
+      if (val is Int) return doubleLexical(val.toStr, context)
+      float := val as Float
+      if (float != null) return doubleLexical(float.toStr, context)
+      num := val as Number
+      if (num == null || num.unit != null)
+        throw UnsupportedErr("Expected unitless Float for ${context}, not ${val.typeof}")
+      return doubleLexical(num.toFloat.toStr, context)
+    }
+
+    if (qname == "sys::Bool")
+    {
+      if (val is Bool) return val.toStr
+      str := val as Str
+      if (str == "true" || str == "false") return str
+      throw UnsupportedErr("Expected Bool for ${context}, not ${val.typeof}")
+    }
+
+    if (qname == "sys::Date")
+    {
+      if (val is Date) return val.toStr
+      str := val as Str
+      if (str != null && Date.fromStr(str, false) != null) return str
+      throw UnsupportedErr("Expected Date for ${context}, not ${val.typeof}")
+    }
+
+    if (qname == "sys::Time")
+    {
+      if (val is Time) return val.toStr
+      str := val as Str
+      if (str != null && Time.fromStr(str, false) != null) return str
+      throw UnsupportedErr("Expected Time for ${context}, not ${val.typeof}")
+    }
+
+    if (qname == "sys::DateTime")
+    {
+      if (val is DateTime) return ((DateTime)val).toIso
+      str := val as Str
+      if (str != null && DateTime.fromStr(str, false) != null) return str
+      throw UnsupportedErr("Expected DateTime for ${context}, not ${val.typeof}")
+    }
+
+    if (qname == "sys::Uri")
+    {
+      if (val is Uri) return val.toStr
+      str := val as Str
+      if (str != null && Uri.fromStr(str, false) != null) return str
+      throw UnsupportedErr("Expected Uri for ${context}, not ${val.typeof}")
+    }
+
+    if (qname == "sys::TimeZone")
+    {
+      if (val is TimeZone) return val.toStr
+      str := val as Str
+      if (str != null && TimeZone.fromStr(str, false) != null) return str
+      throw UnsupportedErr("Expected TimeZone for ${context}, not ${val.typeof}")
+    }
+
+    throw UnsupportedErr("RDF scalar value mapping not supported for ${context} of ${qname}")
   }
 
   private This global(Spec x)
   {
-    // don't generate globals, just class properties
-    // prop(x)
-    return this
+    return prop(x)
   }
 
   private This slot(Spec x)
@@ -420,6 +1091,8 @@ class RdfExporter : Exporter
   {
     qname(x.qname).nl
     w("  a sys:Marker ;").nl
+    if (x.base != null && !x.base.isType)
+      w("  rdfs:subPropertyOf ").qname(x.base.qname).w(" ;").nl
     labelAndDoc(x)
     w(".").nl
     return this
@@ -429,24 +1102,28 @@ class RdfExporter : Exporter
   {
     qname(x.qname).nl
     w("  a rdf:Property ;").nl
-    if (!x.base.isType)
-      w("  rdfs:subClassOf ").qname(x.base.qname).w("; ").nl
+    if (x.base != null && !x.base.isType)
+      w("  rdfs:subPropertyOf ").qname(x.base.qname).w(" ;").nl
     labelAndDoc(x)
-    type := globalType(x)
-    // if (type != null) w("  rdfs:range ").w(type).w(" ;").nl
     w(".").nl
     return this
   }
 
-  private Str? globalType(Spec x)
+  ** Sealed is a schema validity rule rather than an RDF statement. Xeto's
+  ** compiler normally prevents this state, but an exporter must still fail
+  ** closed if handed a namespace assembled by another implementation.
+  private Void validateSealedNamespace(Lib lib)
   {
-    type := x.type
-    if (type.qname == "sys::Str") return "xsd:string"
-    if (type.qname == "sys::Int") return "xsd:integer"
-    if (type.isEnum) return qnameToUri(type.qname)
-    if (type.isChoice) return qnameToUri(type.qname)
-    if (type.isRef || type.isMultiRef) return x.of(false)?.qname ?: "sys:Entity"
-    return null
+    candidates := Str:Spec[:]
+    ns.eachType |candidate| { candidates[candidate.qname] = candidate }
+    lib.types.each |candidate| { candidates[candidate.qname] = candidate }
+    candidates.each |candidate|
+    {
+      base := candidate.base
+      if (base == null) return
+      if (base.lib.name != candidate.lib.name && base.meta.has("sealed"))
+        throw UnsupportedErr("External subtype ${candidate.qname} extends sealed spec ${base.qname}")
+    }
   }
 
   private This labelAndDoc(Spec x)
@@ -466,86 +1143,376 @@ class RdfExporter : Exporter
   {
     id := instance.id
 
-    // TODO - just hide op/filetype instances for now
-    if (id.toStr.startsWith("ph::op:")) return this
-    if (id.toStr.startsWith("ph::filetype:")) return this
-
-    spec := ns.specOf(instance)
-    dis := instance.dis.trim
-    members := spec.members
-
-    markers := Str:Spec[:]
-    refs    := Str:Spec[:]
-    enums   := Str:Spec[:]
-    vals    := Str:Spec[:]
-    instance.each |v, n|
-    {
-      if (n == "id") return
-      if (n == "dis" || n == "disMacro") return
-
-      slot := members.get(n, false)
-      if (slot == null) return
-      if (slot.isChoice) return // handled below
-
-      type := slot.type
-      if (v == Marker.val)  markers[n] = slot
-      else if (v is Ref)    refs[n] = slot
-      else if (type.isEnum) enums[n] = slot
-      else vals[n] = slot
-    }
-
+    spec := instanceSpec(instance)
     this.id(id).nl
-    w("  rdf:type ").qname(spec.qname).w(" ;").nl
-    w("  rdfs:label ").literal(dis).w(" ;").nl
-    markers.keys.sort.each |n| { instanceMarker(instance, n, markers[n]) }
-    refs.keys.sort.each  |n| { instanceRef(instance, n, refs[n]) }
-    enums.keys.sort.each |n| { instanceEnum(instance, n, enums[n]) }
-    vals.keys.sort.each  |n| { instanceVal(instance, n, vals[n]) }
+    w("  a ").w(isSys ? ":Entity" : "sys:Entity").w(", ").qname(spec.qname).w(" ;").nl
+    instanceMembers(instance, spec, "  ")
     spec.slots.each |s| { if (s.isChoice) instanceChoice(instance, s) }
     w(".").nl
     return this
   }
 
-  private Void instanceMarker(Dict instance, Str name, Spec slot)
+  private Void instanceMembers(Dict instance, Spec spec, Str indent)
   {
-    w("  sys:hasMarker ").qname(slot.qname).w(" ;").nl
+    storedNames := Str:Bool[:]
+    instance.each |val, name| { storedNames[name] = true }
+
+    choiceMarkers := Str:Bool[:]
+    spec.slots.each |slot|
+    {
+      if (!slot.isChoice) return
+      instanceChoiceSelections(instance, slot).each |selection|
+      {
+        selection.slots.each |marker|
+        {
+          if (marker.isMarker) choiceMarkers[marker.name] = true
+        }
+      }
+    }
+
+    members := ns.reflect(instance, spec).members.dup
+    members.sort |a, b| { instanceProperty(spec, a) <=> instanceProperty(spec, b) }
+    members.each |member|
+    {
+      if (member.name == "id" || member.name == "spec" || member.isChoice) return
+      if (choiceMarkers.containsKey(member.name)) return
+
+      slot := instanceMemberSpec(spec, member)
+      val := storedNames.containsKey(member.name) ? member.val : null
+      if (val == null) return
+
+      // The runtime Ref type uses @x as an internal construction placeholder.
+      // Only export it when the instance actually authored that member.
+      ref := val as Ref
+      if (ref != null && ref.id == "x" && !storedNames.containsKey(member.name)) return
+
+      // Slots and globals both wrap their value type. Parameterized list
+      // metadata such as `of` and size constraints remains on that wrapper.
+      isMember := slot.isSlot || slot.isGlobal
+      type := isMember && slot.type.isList ? slot : (isMember ? slot.type : slot)
+      instanceProperties(spec, member).each |property|
+      {
+        instanceMember(property, type, val, indent)
+      }
+    }
   }
 
-  private Void instanceRef(Dict instance, Str name, Spec slot)
+  private Str[] instanceProperties(Spec parent, ReflectMember member)
   {
-    ref := instance[name]
-    if (ref == null) return
-    w("  ").qname(slot.qname).w(" ").id(ref).w(" ;").nl
+    spec := instanceMemberSpec(parent, member)
+    properties := Str:Bool[:]
+    properties[instanceProperty(parent, member)] = true
+    while (spec.isSlot && spec.base != null && (spec.base.isSlot || spec.base.isGlobal))
+    {
+      spec = spec.base
+      properties[spec.qname] = true
+    }
+    return properties.keys.sort
   }
 
-  private Void instanceEnum(Dict instance, Str name, Spec slot)
+  private Str instanceProperty(Spec parent, ReflectMember member)
   {
-    key := instance[name]?.toStr
-    if (key == null) return
-    item := slot.type.enum.spec(key, false)
-    if (item == null) return
-    w("  ").qname(slot.qname).w(" ").w(enumItemUri(item)).w(" ;").nl
+    spec := instanceMemberSpec(parent, member)
+    return spec.isSlot ? spec.qname : "${parent.qname}.${member.name}"
   }
 
-  private Void instanceVal(Dict instance, Str name, Spec slot)
+  ** Reflection exposes a mixin slot as the target library's materialized
+  ** effective slot. Recover this exporting library's declaration so instance
+  ** properties retain the contributor qname and its original type contract.
+  private Spec instanceMemberSpec(Spec parent, ReflectMember member)
   {
-    val := instance[name]
-    if (val == null) return
-    w("  ").qname(slot.qname).w(" ").literal(val.toStr).w(" ;").nl
+    cacheKey := "${parent.qname}.${member.name}"
+    cached := instanceMemberSpecs[cacheKey]
+    if (cached != null) return cached
+
+    // Include installed namespace libraries for direct instance() export, then
+    // overlay curLib because a temporary library is not necessarily installed.
+    libs := Str:Lib[:]
+    ns.libs.each |lib| { libs[lib.name] = lib }
+    if (curLib != null) libs[curLib.name] = curLib
+
+    matches := Str:Spec[:]
+    libs.each |lib|
+    {
+      lib.mixins.each |contribution|
+      {
+        target := contribution.base
+        if (target == null)
+          throw UnsupportedErr("Mixin contribution ${contribution.qname} has no target spec")
+        if (!parent.isa(target)) return
+
+        slot := contribution.slotOwn(member.name, false)
+        if (slot == null) return
+        previous := matches[slot.qname]
+        if (previous != null && previous !== slot)
+          throw UnsupportedErr("Ambiguous mixin property for ${parent.qname}.${member.name}: ${slot.qname}")
+        matches[slot.qname] = slot
+      }
+    }
+
+    if (matches.size > 1)
+    {
+      names := matches.keys.sort.join(", ")
+      throw UnsupportedErr("Ambiguous mixin property for ${parent.qname}.${member.name}: ${names}")
+    }
+    resolved := matches.vals.first ?: member.spec
+    instanceMemberSpecs[cacheKey] = resolved
+    return resolved
+  }
+
+  private Void instanceMember(Str property, Spec type, Obj val, Str indent)
+  {
+    if (val == Marker.val)
+    {
+      w(indent).w(isSys ? ":hasMarker" : "sys:hasMarker").w(" ").qname(property).w(" ;").nl
+      return
+    }
+
+    if (type.isRef)
+    {
+      ref := val as Ref ?: throw UnsupportedErr("Expected Ref for ${property}, not ${val.typeof}")
+      w(indent).qname(property).w(" ").id(ref).w(" ;").nl
+      return
+    }
+
+    if (type.isMultiRef)
+    {
+      instanceMultiRef(property, val, indent)
+      return
+    }
+
+    if (type.qname == "sys::TimeZone")
+    {
+      w(indent).qname(property).w(" ")
+      typedLiteral(val, type, property)
+      w(" ;").nl
+      return
+    }
+
+    if (type.isEnum)
+    {
+      if (type.qname == "sys::Unit")
+      {
+        unit := val as Unit ?: throw UnsupportedErr("Expected Unit for ${property}, not ${val.typeof}")
+        w(indent).qname(property).w(" ").w(qudt.unit(unit)).w(" ;").nl
+        return
+      }
+      if (type.qname == "sys::UnitQuantity")
+        throw UnsupportedErr("RDF UnitQuantity mapping not supported for ${property} of ${type.qname}")
+      scalar := val as Scalar
+        ?: throw UnsupportedErr("Expected ${type.qname} enum value for ${property}, not ${val.typeof}")
+      if (scalar.qname != type.qname)
+        throw UnsupportedErr("Expected ${type.qname} enum value for ${property}, not ${scalar.qname}")
+      key := scalar.val
+      if (type.enum.spec(key, false) == null)
+        throw UnsupportedErr("Invalid ${type.qname} value: ${key}")
+      w(indent).qname(property).w(" ").literal(key).w("^^xsd:string ;").nl
+      return
+    }
+
+    if (type.isList)
+    {
+      instanceList(property, type, val, indent)
+      return
+    }
+
+    if (type.isDict)
+    {
+      nested := val as Dict ?: throw UnsupportedErr("Expected Dict for ${property}, not ${val.typeof}")
+      instanceNested(property, nested, indent)
+      return
+    }
+
+    if (type.isScalar && !type.isRef)
+    {
+      num := val as Number
+      if (num != null && num.unit != null)
+      {
+        instanceQuantityValue(property, num, indent)
+        return
+      }
+      w(indent).qname(property).w(" ")
+      typedLiteral(val, type, property)
+      w(" ;").nl
+      return
+    }
+
+    if (type.qname == "sys::Obj")
+    {
+      actual := ns.specOf(val, false)
+      if (actual == null || actual.qname == "sys::Obj")
+        throw UnsupportedErr("RDF Obj value type is ambiguous for ${property}: ${val.typeof}")
+      instanceMember(property, actual, val, indent)
+      return
+    }
+
+    throw UnsupportedErr("RDF instance value mapping not supported for ${property} of ${type.qname}")
+  }
+
+  private Void instanceQuantityValue(Str property, Number num, Str indent)
+  {
+    unit := num.unit ?: throw UnsupportedErr("Expected unit-bearing Number for ${property}")
+    value := doubleLexical(num.toFloat.toStr, property)
+    w(indent).qname(property).w(" [").nl
+    w(indent).w("  a qudt:QuantityValue ;").nl
+    w(indent).w("  qudt:numericValue ").literal(value).w("^^xsd:double ;").nl
+    w(indent).w("  qudt:unit ").w(qudt.unit(unit)).nl
+    w(indent).w("] ;").nl
+  }
+
+  private Void instanceMultiRef(Str property, Obj val, Str indent)
+  {
+    if (val is Ref)
+    {
+      instanceRefValue(property, val, indent)
+      return
+    }
+
+    refs := val as List
+    if (refs != null)
+    {
+      refs.each |item|
+      {
+        ref := item as Ref ?: throw UnsupportedErr("Expected Ref item for ${property}, not ${item.typeof}")
+        instanceRefValue(property, ref, indent)
+      }
+      return
+    }
+
+    // Source-declared MultiRef blocks remain Dicts in Lib.instances; their
+    // generated slots carry the same refs returned by instantiated Ref[].
+    dict := val as Dict ?: throw UnsupportedErr("Expected Ref, Ref[], or MultiRef Dict for ${property}, not ${val.typeof}")
+    dict.each |item, name|
+    {
+      if (name == "id" || name == "spec") return
+      ref := item as Ref ?: throw UnsupportedErr("Expected Ref item for ${property}.${name}, not ${item.typeof}")
+      instanceRefValue(property, ref, indent)
+    }
+  }
+
+  private Void instanceRefValue(Str property, Ref ref, Str indent)
+  {
+    w(indent).qname(property).w(" ").id(ref).w(" ;").nl
+  }
+
+  private Void instanceNested(Str property, Dict nested, Str indent)
+  {
+    nestedId := nested["id"] as Ref
+    if (nestedId != null)
+    {
+      w(indent).qname(property).w(" ").id(nestedId).w(" ;").nl
+      return
+    }
+
+    nestedSpec := instanceSpec(nested)
+    w(indent).qname(property).w(" [").nl
+    w(indent).w("  a ").qname(nestedSpec.qname).w(" ;").nl
+    instanceMembers(nested, nestedSpec, indent + "  ")
+    w(indent).w("] ;").nl
+  }
+
+  private Void instanceList(Str property, Spec listType, Obj val, Str indent)
+  {
+    items := val as List ?: throw UnsupportedErr("Expected List for ${property}, not ${val.typeof}")
+    of := listType.of(false)
+    validateListItemType(listType, of)
+
+    w(indent).qname(property).w(" (")
+    if (!items.isEmpty) nl
+    items.each |item|
+    {
+      w(indent).w("  ")
+      instanceListItem(property, of, item, indent + "  ")
+      nl
+    }
+    if (!items.isEmpty) w(indent)
+    w(") ;").nl
+  }
+
+  private Void instanceListItem(Str property, Spec? declaredType, Obj item, Str indent)
+  {
+    type := declaredType ?: ns.specOf(item, false)
+    if (type == null)
+      throw UnsupportedErr("RDF list item type not known for ${property}: ${item.typeof}")
+    validateListItemType(type, type)
+
+    if (type.isScalar)
+    {
+      num := item as Number
+      if (num != null && num.unit != null)
+        throw UnsupportedErr("RDF quantity list item mapping not supported for ${property}")
+      typedLiteral(item, type, property)
+      return
+    }
+
+    if (type.isDict)
+    {
+      nested := item as Dict ?: throw UnsupportedErr("Expected Dict item for ${property}, not ${item.typeof}")
+      nestedId := nested["id"] as Ref
+      if (nestedId != null)
+      {
+        id(nestedId)
+        return
+      }
+
+      nestedSpec := instanceSpec(nested)
+      w("[").nl
+      w(indent).w("  a ").qname(nestedSpec.qname).w(" ;").nl
+      instanceMembers(nested, nestedSpec, indent + "  ")
+      w(indent).w("]")
+      return
+    }
+
+    throw UnsupportedErr("RDF list item mapping not supported for ${property}: ${type.qname}")
   }
 
   private Void instanceChoice(Dict instance, Spec slot)
   {
-    selected := ns.choice(slot).selections(instance, false)
+    selected := instanceChoiceSelections(instance, slot)
     selected.each |x|
     {
       w("  ").qname(slot.qname).w(" ").qname(x.qname).w(" ;").nl
     }
   }
 
+  private Spec[] instanceChoiceSelections(Dict instance, Spec slot)
+  {
+    selected := choiceMembers(slot).findAll |Spec candidate->Bool|
+    {
+      markers := candidate.slots.list.findAll |Spec memberSlot->Bool| { memberSlot.isMarker }
+      return markers.all |Spec marker->Bool| { instance.has(marker.name) }
+    }
+    return XetoUtil.excludeSupertypes(selected)
+  }
+
+  private Spec instanceSpec(Dict instance)
+  {
+    spec := ns.specOf(instance, false)
+    if (spec != null) return spec
+
+    specRef := instance["spec"] as Ref
+    qname := specRef?.toStr
+    lib := curLib
+    if (qname != null && lib != null && qname.startsWith("${lib.name}::"))
+      return lib.spec(qname[qname.index("::") + 2..-1])
+
+    throw UnknownSpecErr(qname ?: instance.typeof.qname)
+  }
+
 //////////////////////////////////////////////////////////////////////////
 // Utils
 //////////////////////////////////////////////////////////////////////////
+
+  private Lib? curLib
+  private Str:Spec instanceMemberSpecs := [:]
+  private Bool instancesOnly
+  private Bool schemaOnly
+  private RdfQudtMap? qudtRef
+
+  private RdfQudtMap qudt()
+  {
+    qudtRef ?: (qudtRef = RdfQudtMap.load)
+  }
 
   ** Convert library to its RDF URI
   private Str libUri(Lib lib)
@@ -561,39 +1528,131 @@ class RdfExporter : Exporter
   }
 
   ** Turn Xeto qname into RDF URI
-  static Str qnameToUri(Str qname)
+  private Str qnameToUri(Str qname)
   {
-    qname.replace("::", ":")
+    requireQNameLibrary(qname, "RDF name")
+    return qname.replace("::", ":")
   }
 
   ** Output Xeto lib::name qualified name
   private This qname(Str qname)
   {
-    w(qnameToUri(qname))
+    return w(qnameToUri(qname))
   }
 
   ** Output Xeto lib::name qualified name
   private This id(Ref id)
   {
-    w(qnameToUri(id.toStr))
+    qname := id.toStr
+    sep := qname.index("::")
+    if (sep == null || sep == 0 || sep + 2 >= qname.size || qname.index("::", sep + 2) != null)
+      throw UnsupportedErr("RDF instance id or reference is not library-qualified: ${qname}")
+
+    libName := qname[0..<sep]
+    local := qname[sep + 2..-1]
+    lib := requireLibrary(libName)
+
+    // Keep ordinary Xeto qnames readable. Ref ids may also contain schemes
+    // such as `op:name` and `filetype:json`; those are legal RDF fragments
+    // but not legal prefixed names, so write their full versioned IRI.
+    if (isSafePrefixedLocal(local))
+      return w(libName).w(":").w(local)
+
+    encoded := Uri.encodeToken(local, Uri.sectionFrag)
+    return w("<").w(libUri(lib)).w("#").w(encoded).w(">")
+  }
+
+  private Void validateQName(Str qname, Str kind)
+  {
+    sep := qname.index("::")
+    invalid := sep == null || sep == 0 || sep + 2 >= qname.size ||
+      qname.index("::", sep + 2) != null || qname[sep + 2..-1].contains(":") ||
+      qname.contains(" ") || qname.contains("\t") || qname.contains("\r") ||
+      qname.contains("\n") || qname.contains("<") || qname.contains(">") ||
+      qname.contains("\"") || qname.contains("\\")
+    if (invalid) throw UnsupportedErr("${kind} is not QName-compatible: ${qname}")
+  }
+
+  ** Resolve a qname against the pinned namespace before emitting its prefix.
+  private Lib requireQNameLibrary(Str qname, Str kind)
+  {
+    validateQName(qname, kind)
+    sep := qname.index("::") ?: throw UnsupportedErr("${kind} is not QName-compatible: ${qname}")
+    return requireLibrary(qname[0..<sep])
+  }
+
+  ** Resolve one library to the concrete version selected by this namespace.
+  private Lib requireLibrary(Str name)
+  {
+    lib := curLib?.name == name ? curLib : ns.lib(name, false)
+    if (lib == null)
+      throw UnsupportedErr("Concrete Xeto library version unavailable for ${name}")
+    return lib
+  }
+
+  ** A Namespace promises one pinned version per library. Check that invariant
+  ** explicitly so RDF export also fails closed for custom Namespace providers.
+  private Void validateNamespaceVersions(Lib lib)
+  {
+    selected := Str:Version[:]
+    selected[lib.name] = lib.version
+    ns.versions.each |libVersion|
+    {
+      previous := selected[libVersion.name]
+      if (previous != null && previous != libVersion.version)
+        throw UnsupportedErr("Ambiguous Xeto library version for ${libVersion.name}: ${previous} and ${libVersion.version}")
+      selected[libVersion.name] = libVersion.version
+    }
+  }
+
+  ** Return true when a local name can follow a Turtle prefix without escaping.
+  private Bool isSafePrefixedLocal(Str local)
+  {
+    if (local.isEmpty || local.endsWith(".")) return false
+    return local.all |char, index|
+    {
+      if (char.isAlphaNum && char < 128) return true
+      if (char == '_') return true
+      if (index > 0 && (char == '-' || char == '.')) return true
+      return false
+    }
+  }
+
+  ** Parse one Xeto Number through Fantom's binary Float value and use its
+  ** stable shortest round-trippable spelling as the xsd:double lexical form.
+  private Str doubleLexical(Str source, Str context)
+  {
+    if (source == "NaN" || source == "INF" || source == "-INF") return source
+    value := Float.fromStr(source, false)
+    if (value == null)
+      throw UnsupportedErr("Invalid RDF double for ${context}: ${source}")
+    if (value.isNaN) return "NaN"
+    if (value == Float.posInf) return "INF"
+    if (value == Float.negInf) return "-INF"
+    return value.toStr.replace("e", "E")
   }
 
   ** Quoted string literal
   private This literal(Str s)
   {
-    lines := s.splitLines
-    if (lines.size <= 1)
+    wc('"')
+    s.each |char|
     {
-      w(lines[0].toCode('"').replace(Str<|\$|>, Str<|$|>))
+      switch (char)
+      {
+        case '\b': w("\\b")
+        case '\f': w("\\f")
+        case '\n': w("\\n")
+        case '\r': w("\\r")
+        case '\t': w("\\t")
+        case '\\': w("\\\\")
+        case '"':  w("\\\"")
+        default:
+          if (char <= 0x1f || char == 0x7f) w("\\u").w(char.toHex(4).upper)
+          else wc(char)
+      }
     }
-    else
-    {
-      indent := "    "
-      w(Str<|"""|>).nl
-      lines.each |line| { w(indent).w(line.toCode(null).replace(Str<|\$|>, Str<|$|>)).nl }
-      w("    ").w(Str<|"""|>)
-    }
-    return this
+    return wc('"')
   }
 
 //////////////////////////////////////////////////////////////////////////
@@ -601,4 +1660,5 @@ class RdfExporter : Exporter
 //////////////////////////////////////////////////////////////////////////
 
   private Bool isSys
+  private static const Regex queryPathRef := Regex<|(?:[A-Za-z_][A-Za-z0-9_]*|[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*|[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*::[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*)|>
 }

--- a/src/test/testXeto/fan/RdfTest.fan
+++ b/src/test/testXeto/fan/RdfTest.fan
@@ -40,6 +40,24 @@ class RdfTest : AbstractXetoTest
     verifyEq(countMatches(rdf, "temp:Person.dis\n  a rdf:Property ;"), 1)
   }
 
+  Void testAbstractSpecRejectsDirectType()
+  {
+    rdf := export(
+      Str<|AbstractThing : Dict <abstract> {
+               dis: Str
+             }
+
+             ConcreteThing : AbstractThing|>)
+
+    abstractRdf := rdf[rdf.index("temp:AbstractThing\n")..<rdf.index("temp:ConcreteThing\n")]
+    verify(abstractRdf.contains("a sh:NodeShape ;"), abstractRdf)
+    verify(abstractRdf.contains("sh:path rdf:type ;"), abstractRdf)
+    verify(abstractRdf.contains("sh:hasValue temp:AbstractThing"), abstractRdf)
+
+    concrete := rdf[rdf.index("temp:ConcreteThing\n")..-1]
+    verifyFalse(concrete.contains("sh:hasValue temp:ConcreteThing"), concrete)
+  }
+
   Void testScalarConstraints()
   {
     rdf := export(
@@ -64,7 +82,7 @@ class RdfTest : AbstractXetoTest
     verify(rdf.contains("sh:path temp:Reading.count ;\n    sh:datatype xsd:integer ;"))
     verify(rdf.contains("sh:minInclusive 1 ;"))
     verify(rdf.contains("sh:maxInclusive 60 ;"))
-    verify(rdf.contains("sh:path temp:Reading.value ;\n    sh:datatype xsd:decimal ;"))
+    verify(rdf.contains("sh:path temp:Reading.value ;\n    sh:datatype xsd:double ;"))
     verify(rdf.contains("sh:path temp:Reading.enabled ;\n    sh:datatype xsd:boolean ;"))
     verify(rdf.contains("sh:path temp:Reading.commissioned ;\n    sh:datatype xsd:date ;"))
     verify(rdf.contains("sh:path temp:Reading.code ;\n    sh:datatype xsd:string ;"))
@@ -81,7 +99,7 @@ class RdfTest : AbstractXetoTest
   {
     rdf := export(
       Str<|Reading : Dict {
-               decimal: Number <minVal:1.5, maxVal:2.5>
+               value: Number <minVal:1.5, maxVal:2.5>
                observedAt: Time
                timestamp: DateTime
                source: Uri
@@ -94,10 +112,10 @@ class RdfTest : AbstractXetoTest
                defaulted: Str "fallback"
              }|>)
 
-    decimal := propertyShape(rdf, "Reading.decimal")
-    verify(decimal.contains("sh:datatype xsd:decimal ;"))
-    verify(decimal.contains("sh:minInclusive 1.5 ;"))
-    verify(decimal.contains("sh:maxInclusive 2.5 ;"))
+    value := propertyShape(rdf, "Reading.value")
+    verify(value.contains("sh:datatype xsd:double ;"))
+    verify(value.contains("sh:minInclusive \"1.5\"^^xsd:double ;"))
+    verify(value.contains("sh:maxInclusive \"2.5\"^^xsd:double ;"))
 
     verify(propertyShape(rdf, "Reading.observedAt").contains("sh:datatype xsd:time ;"))
     verify(propertyShape(rdf, "Reading.timestamp").contains("sh:datatype xsd:dateTime ;"))
@@ -133,6 +151,117 @@ class RdfTest : AbstractXetoTest
     verifyEq(export(src), export(src))
   }
 
+  Void testCompleteSupportedProfileClosure()
+  {
+    src := Str<|Code : Scalar <pattern:"[A-Z]{2}">
+
+                 Suit : Enum { clubs <key:"Clubs"> }
+                 HeatingProcess : Choice
+                 HotWaterHeating : HeatingProcess { hotWaterHeating }
+                 SteamHeating : HeatingProcess { steamHeating }
+
+                 Site : Dict { dis: Str }
+                 Related : Dict
+                 Address : Dict { city: Str }
+                 Named : Dict { dis: Str }
+                 Located : Dict { geoCity: Str }
+                 NamedLocation : Named & Located
+                 Heating : Dict
+                 Cooling : Dict
+                 ThermalProcess : Heating | Cooling
+
+                 Asset : Dict {
+                   *height: Number?<minVal:0, maxVal:300>
+                   *tracked: Marker?
+                 }
+
+                 Equip : Asset <doc:"Line one\nLine \"two\" \\ dollar \$"> {
+                   label: Str <nonEmpty, minSize:2, maxSize:40>
+                   code: Code
+                   count: Int <minVal:1, maxVal:60>
+                   value: Number
+                   enabled: Bool
+                   commissioned: Date
+                   observedAt: Time
+                   timestamp: DateTime
+                   source: Uri
+                   zone: TimeZone
+                   anything: Obj
+                   suit: Suit
+                   siteRef: Ref<of:Site>
+                   related: MultiRef?<of:Related>
+                   address: Address
+                   names: List<of:Str, minSize:2, maxSize:3>
+                   addresses: List<of:Address, nonEmpty>
+                   heatingProcesses: HeatingProcess <multiChoice>
+                   points: Query<of:Related, via:"related*">
+                   equip
+                   fixed: Str <invariant> "ok"
+                   height: Int?<minVal:100>
+                   tracked: Marker
+                   unit: Unit <quantity:"temperature">
+                   percent: Number <unit:"%">
+                 }
+
+                 @site1: Site { dis:"HQ" }
+                 @related1: Related {}
+                 @equip1: Equip {
+                   label: "AHU-1"
+                   code: Code "AB"
+                   count: 7
+                   value: 1.5
+                   enabled: "true"
+                   commissioned: 2026-08-18
+                   observedAt: 02:30:00
+                   timestamp: 2026-08-18T10:00:00Z
+                   source: Uri "https://example.com/a?x=1&y=2"
+                   zone: TimeZone "Chicago"
+                   anything: "free"
+                   suit: "Clubs"
+                   siteRef: @site1
+                   related: MultiRef { @related1 }
+                   address: Address { city:"Richmond" }
+                   names: {"first", "second"}
+                   addresses: { Address { city:"Norfolk" } }
+                   hotWaterHeating
+                   steamHeating
+                   equip
+                   imported
+                   unit: Unit "°F"
+                   percent: Number "50%"
+                 }|>
+
+    first := export(src)
+    second := export(src)
+    verifyEq(first, second)
+
+    equip := instanceBlock(first, "equip1")
+    verify(equip.contains("temp:Equip.label \"AHU-1\"^^xsd:string ;"), equip)
+    verify(equip.contains("temp:Equip.observedAt \"02:30:00\"^^xsd:time ;"), equip)
+    verify(equip.contains("temp:Equip.timestamp \"2026-08-18T10:00:00Z\"^^xsd:dateTime ;"), equip)
+    verify(equip.contains("temp:Equip.source \"https://example.com/a?x=1&y=2\"^^xsd:anyURI ;"), equip)
+    verify(equip.contains("temp:Equip.anything \"free\"^^xsd:string ;"), equip)
+    verify(equip.contains("temp:Equip.siteRef temp:site1 ;"), equip)
+    verify(equip.contains("temp:Equip.address ["), equip)
+    verify(equip.contains("temp:Equip.names ("), equip)
+    verify(equip.contains("temp:Equip.heatingProcesses temp:HotWaterHeating ;"), equip)
+    verify(equip.contains("qudt:numericValue \"50.0\"^^xsd:double ;"), equip)
+    verify(equip.contains("sys:hasMarker temp:Equip.imported ;"), equip)
+    verifyFalse(equip.contains("temp:Equip.points"), equip)
+
+    firstName := equip.index("\"first\"^^xsd:string")
+    secondName := equip.index("\"second\"^^xsd:string")
+    verify(firstName != null && secondName != null && firstName < secondName, equip)
+    verify(first.contains("rdfs:comment \"Line one\\nLine \\\"two\\\" \\\\ dollar \$\"@en"), first)
+    verify(first.contains("sh:zeroOrMorePath temp:Equip.related"), first)
+    verify(first.contains("rdfs:subPropertyOf temp:Asset.height ;"), first)
+    verify(first.contains("temp:Equip.tracked\n  a sys:Marker ;\n  rdfs:subPropertyOf temp:Asset.tracked ;"), first)
+    verify(first.contains("rdfs:subClassOf temp:Named, temp:Located ;"), first)
+    verify(first.contains("temp:Heating rdfs:subClassOf temp:ThermalProcess ."), first)
+    verify(first.contains("temp:Cooling rdfs:subClassOf temp:ThermalProcess ."), first)
+    verifyFalse(propertyShape(first, "Equip.zone").contains("sh:in"), first)
+  }
+
   Void testUnsupportedSystemScalarFailsClosed()
   {
     verifyErrMsg(UnsupportedErr#, "RDF scalar datatype not supported: sys::Version")
@@ -141,24 +270,704 @@ class RdfTest : AbstractXetoTest
     }
   }
 
+  Void testUnmappedMetadataIsOmitted()
+  {
+    plain := export(Str<|Person : Dict { dis: Str }|>)
+    annotated := export(
+      Str<|+Spec { icon: Str? }
+
+             Person : Dict <icon:"user"> {
+               dis: Str <icon:"label">
+             }|>)
+
+    verifyEq(resourceBlock(annotated, "temp:Person"), resourceBlock(plain, "temp:Person"))
+    verifyEq(resourceBlock(annotated, "temp:Person.dis"), resourceBlock(plain, "temp:Person.dis"))
+    verifyFalse(annotated.contains("icon"), annotated)
+  }
+
+  Void testOtherCoreTypeInventory()
+  {
+    rdf := export(
+      Str<|Failure : Err
+             Envelope : Dict { failure: Failure? }|>)
+    verify(rdf.contains("temp:Failure\n  a sys:Class ;"), rdf)
+    verify(rdf.contains("rdfs:subClassOf sys:Err ;"), rdf)
+    verify(propertyShape(rdf, "Envelope.failure").contains("sh:node temp:Failure ;"), rdf)
+
+    ["None", "NA", "Duration", "Version", "Buf", "Span", "Filter", "BuildVar"].each |type|
+    {
+      verifyUnsupported("Holder : Dict { value: ${type} }", "RDF scalar datatype not supported: sys::${type}")
+    }
+    verifyUnsupported("Holder : Dict { value: Grid }", "RDF Grid mapping not supported")
+    verifyUnsupported("Holder : Dict { value: Collection }", "RDF Collection mapping not supported")
+    verifyUnsupported("Holder : Dict { value: Func }", "RDF Func mapping not supported")
+    verifyUnsupported("Holder : Dict { value: Interface }", "RDF Interface mapping not supported")
+    verifyUnsupported("Holder : Dict { value: Funcs }", "RDF Interface mapping not supported")
+  }
+
+  Void testClosureDiagnosticsFailClosed()
+  {
+    try
+    {
+      export(Str<|Point : Dict
+                   Equip : Dict { points: Query { point: Point } }|>)
+      fail("Expected required query body member to fail closed")
+    }
+    catch (UnsupportedErr err)
+    {
+      verify(err.msg.contains("RDF query body mapping not supported for required member"), err.msg)
+      verify(err.msg.endsWith("::Equip.points.point"), err.msg)
+    }
+
+    try
+    {
+      export(Str<|Node : Dict { parent: Ref<of:This> }|>)
+      fail("Expected parent-relative Ref to fail closed")
+    }
+    catch (UnsupportedErr err)
+    {
+      verify(err.msg.contains("RDF parent-relative This mapping not supported for"), err.msg)
+      verify(err.msg.endsWith("::Node.parent"), err.msg)
+    }
+
+    ns := createNamespace(["sys"])
+    colonId := Etc.makeDict(["id":Ref("sys::op:bad"), "spec":Ref("sys::Dict")])
+    buf := Buf()
+    RdfExporter(ns, buf.out, Etc.dict0).start.instance(colonId).end
+    verify(buf.flip.readAllStr.contains("#op:bad>"))
+
+    unknownLibId := Etc.makeDict(["id":Ref("missing.lib::bad"), "spec":Ref("sys::Dict")])
+    verifyErrMsg(UnsupportedErr#, "Concrete Xeto library version unavailable for missing.lib")
+    {
+      RdfExporter(ns, Buf().out, Etc.dict0).start.instance(unknownLibId).end
+    }
+  }
+
+  Void testStructuredValueShapes()
+  {
+    rdf := export(
+      Str<|Suit : Enum {
+               clubs    <key:"Clubs">
+               diamonds <key:"Diamonds">
+             }
+
+             Site : Dict
+             Related : Dict
+             Address : Dict { city: Str }
+
+             Equip : Dict {
+               suit: Suit
+               siteRef: Ref<of:Site>
+               related: MultiRef?<of:Related>
+               address: Address
+             }|>)
+
+    suit := propertyShape(rdf, "Equip.suit")
+    verify(suit.contains("sh:datatype xsd:string ;"), suit)
+    verify(suit.contains("sh:in (\"Clubs\"^^xsd:string \"Diamonds\"^^xsd:string) ;"), suit)
+    verifyFalse(rdf.contains("temp:Suit.clubs"), rdf)
+    suitClass := resourceBlock(rdf, "temp:Suit")
+    verifyFalse(suitClass.contains("a sh:NodeShape"), suitClass)
+
+    siteRef := propertyShape(rdf, "Equip.siteRef")
+    verify(siteRef.contains("sh:nodeKind sh:IRI ;"), siteRef)
+    verify(siteRef.contains("sh:class temp:Site ;"), siteRef)
+    verify(siteRef.contains("sh:minCount 1 ;"), siteRef)
+    verify(siteRef.contains("sh:maxCount 1 ;"), siteRef)
+
+    related := propertyShape(rdf, "Equip.related")
+    verify(related.contains("sh:nodeKind sh:IRI ;"), related)
+    verify(related.contains("sh:class temp:Related ;"), related)
+    verifyFalse(related.contains("sh:minCount"), related)
+    verifyFalse(related.contains("sh:maxCount"), related)
+
+    address := propertyShape(rdf, "Equip.address")
+    verify(address.contains("sh:node temp:Address ;"), address)
+    verify(address.contains("sh:minCount 1 ;"), address)
+    verify(address.contains("sh:maxCount 1 ;"), address)
+  }
+
+  Void testStructuredInstances()
+  {
+    rdf := export(
+      Str<|Suit : Enum { clubs <key:"Clubs"> }
+
+             Site : Dict
+             Related : Dict
+             Address : Dict { city: Str }
+
+             Equip : Dict {
+               dis: Str
+               count: Int
+               enabled: Bool
+               commissioned: Date
+               suit: Suit
+               siteRef: Ref<of:Site>
+               related: MultiRef?<of:Related>
+               address: Address
+               equip
+             }
+
+             Person : Dict { address: Address }
+
+             @site1: Site {}
+             @related1: Related {}
+             @related2: Related {}
+
+             @equip1: Equip {
+               dis: "AHU-1"
+               count: 7
+               enabled: "true"
+               commissioned: 2026-08-11
+               suit: "Clubs"
+               siteRef: @site1
+               related: MultiRef { @related1, @related2 }
+               address: Address { city: "Richmond" }
+               nickname: "Air handler"
+               imported
+             }
+
+             @person1: Person {
+               address @address1: Address { city: "Norfolk" }
+             }|>)
+
+    equip := instanceBlock(rdf, "equip1")
+    verify(equip.contains("a sys:Entity, temp:Equip ;"), equip)
+    verify(equip.contains("temp:Equip.dis \"AHU-1\"^^xsd:string ;"), equip)
+    verify(equip.contains("temp:Equip.count \"7\"^^xsd:integer ;"), equip)
+    verify(equip.contains("temp:Equip.enabled \"true\"^^xsd:boolean ;"), equip)
+    verify(equip.contains("temp:Equip.commissioned \"2026-08-11\"^^xsd:date ;"), equip)
+    verify(equip.contains("temp:Equip.suit \"Clubs\"^^xsd:string ;"), equip)
+    verify(equip.contains("temp:Equip.siteRef temp:site1 ;"), equip)
+    verifyEq(countMatches(equip, "temp:Equip.related "), 2)
+    verify(equip.contains("sys:hasMarker temp:Equip.equip ;"), equip)
+    verify(equip.contains("temp:Equip.address [\n    a temp:Address ;"), equip)
+    verify(equip.contains("temp:Address.city \"Richmond\"^^xsd:string ;"), equip)
+    verify(equip.contains("temp:Equip.nickname \"Air handler\"^^xsd:string ;"), equip)
+    verify(equip.contains("sys:hasMarker temp:Equip.imported ;"), equip)
+    verifyFalse(equip.contains("rdfs:label"), equip)
+
+    person := instanceBlock(rdf, "person1")
+    verify(person.contains("temp:Person.address temp:address1 ;"), person)
+    address := instanceBlock(rdf, "address1")
+    verify(address.contains("a sys:Entity, temp:Address ;"), address)
+    verify(address.contains("temp:Address.city \"Norfolk\"^^xsd:string ;"), address)
+  }
+
+  Void testInheritedGlobalUriInstance()
+  {
+    rdf := exportWithOpts(
+      Str<|Base : Dict {
+               *baseUri: Uri?
+               *unused: Str?
+               *unusedMarker: Marker?
+             }
+
+             Site : Base
+
+             @site1: Site {
+               baseUri: Uri "https://example.com/base/"
+             }|>, Etc.makeDict(["instancesOnly":Marker.val]))
+
+    verify(rdf.contains("temp:Site.baseUri \"https://example.com/base/\"^^xsd:anyURI ;"), rdf)
+    verifyFalse(rdf.contains("unused"), rdf)
+  }
+
+  Void testChoiceShapesAndInstances()
+  {
+    rdf := export(
+      Str<|HeatingProcess : Choice
+             HotWaterHeating : HeatingProcess { hotWaterHeating }
+             SteamHeating : HeatingProcess { steamHeating }
+
+             RequiredEquip : Dict { heatingProcess: HeatingProcess }
+             OptionalEquip : Dict { heatingProcess: HeatingProcess? }
+             MultiEquip : Dict { heatingProcesses: HeatingProcess <multiChoice> }
+             OptionalMultiEquip : Dict { heatingProcesses: HeatingProcess? <multiChoice> }
+
+             @equip1: MultiEquip {
+               hotWaterHeating
+               steamHeating
+             }|>)
+
+    hotWater := resourceBlock(rdf, "temp:HotWaterHeating")
+    verify(hotWater.contains("rdfs:subClassOf temp:HeatingProcess ;"), hotWater)
+    verify(hotWater.contains("sys:hasMarker temp:HotWaterHeating.hotWaterHeating ;"), hotWater)
+    verify(rdf.contains("temp:HotWaterHeating.hotWaterHeating\n  a sys:Marker ;"), rdf)
+
+    required := propertyShape(rdf, "RequiredEquip.heatingProcess")
+    verify(required.contains("sh:in (temp:HotWaterHeating temp:SteamHeating) ;"), required)
+    verify(required.contains("sh:minCount 1 ;"), required)
+    verify(required.contains("sh:maxCount 1 ;"), required)
+
+    optional := propertyShape(rdf, "OptionalEquip.heatingProcess")
+    verifyFalse(optional.contains("sh:minCount"), optional)
+    verify(optional.contains("sh:maxCount 1 ;"), optional)
+
+    multi := propertyShape(rdf, "MultiEquip.heatingProcesses")
+    verify(multi.contains("sh:minCount 1 ;"), multi)
+    verifyFalse(multi.contains("sh:maxCount"), multi)
+
+    optionalMulti := propertyShape(rdf, "OptionalMultiEquip.heatingProcesses")
+    verifyFalse(optionalMulti.contains("sh:minCount"), optionalMulti)
+    verifyFalse(optionalMulti.contains("sh:maxCount"), optionalMulti)
+
+    equip := instanceBlock(rdf, "equip1")
+    verify(equip.contains("temp:MultiEquip.heatingProcesses temp:HotWaterHeating ;"), equip)
+    verify(equip.contains("temp:MultiEquip.heatingProcesses temp:SteamHeating ;"), equip)
+    verifyFalse(equip.contains("sys:hasMarker"), equip)
+  }
+
+  Void testLibraryProjectionProfiles()
+  {
+    src := Str<|Widget : Dict { widget }
+                 @widget1: Widget {}|>
+    schema := exportWithOpts(src, Etc.makeDict(["schemaOnly":Marker.val]))
+    verify(schema.contains("temp:Widget\n  a sys:Class"), schema)
+    verifyFalse(schema.contains("temp:widget1"), schema)
+
+    instances := exportWithOpts(src, Etc.makeDict(["instancesOnly":Marker.val]))
+    verify(instances.contains("temp:widget1"), instances)
+    verify(instances.contains("sys:hasMarker temp:Widget.widget"), instances)
+    verifyFalse(instances.contains("a sh:NodeShape"), instances)
+    verifyFalse(instances.contains("a owl:Ontology"), instances)
+
+    verifyErrMsg(ArgErr#, "instancesOnly and schemaOnly are mutually exclusive")
+    {
+      exportWithOpts(src, Etc.makeDict([
+        "instancesOnly":Marker.val,
+        "schemaOnly":Marker.val,
+      ]))
+    }
+  }
+
+  Void testMixinInstancePropertyOwnership()
+  {
+    rdf := export(
+      Str<|+Entity { orgRef: Ref<of:Org> }
+             Org : Dict
+             Employee : Entity
+
+             @org1: Org {}
+             @entity1: Entity { orgRef: @org1 }
+             @employee1: Employee { orgRef: @org1 }|>)
+
+    entity := instanceBlock(rdf, "entity1")
+    verify(entity.contains("temp:Entity.orgRef temp:org1 ;"), entity)
+    verifyFalse(entity.contains("sys:Entity.orgRef"), entity)
+
+    employee := instanceBlock(rdf, "employee1")
+    verify(employee.contains("temp:Entity.orgRef temp:org1 ;"), employee)
+    verifyFalse(employee.contains("temp:Employee.orgRef"), employee)
+  }
+
+  Void testDirectInstanceFindsInstalledMixinProperty()
+  {
+    ns := createNamespace(["sys", "hx"])
+    instance := Etc.makeDict([
+      "id": Ref("hx::entity1"),
+      "spec": Ref("sys::Entity"),
+      "mod": DateTime("2026-08-26T12:00:00Z UTC")])
+    buf := Buf()
+    RdfExporter(ns, buf.out, Etc.dict0).start.instance(instance).end
+    rdf := buf.flip.readAllStr
+
+    verify(rdf.contains("hx:Entity.mod \"2026-08-26T12:00:00Z\"^^xsd:dateTime ;"), rdf)
+    verifyFalse(rdf.contains("sys:Entity.mod"), rdf)
+  }
+
+  Void testAmbiguousMixinInstancePropertyFailsClosed()
+  {
+    ns := createNamespace(["sys", "hx"])
+    lib := ns.compileTempLib(
+      Str<|+Entity { mod: DateTime? }
+             @entity1: Entity { mod: 2026-08-26T12:00:00Z }|>)
+    try
+    {
+      RdfExporter(ns, Buf().out, Etc.dict0).start.lib(lib).end
+      fail("Expected ambiguous mixin instance property to fail closed")
+    }
+    catch (UnsupportedErr err)
+    {
+      verify(err.msg.startsWith("Ambiguous mixin property for sys::Entity.mod:"), err.msg)
+      verify(err.msg.contains("hx::Entity.mod"), err.msg)
+      verify(err.msg.contains("${lib.name}::Entity.mod"), err.msg)
+    }
+  }
+
+  Void testMissingMixinTargetRejectedAtCompileBoundary()
+  {
+    ns := createNamespace(["sys"])
+    try
+    {
+      ns.compileTempLib("+Missing { value: Str? }")
+      fail("Expected missing mixin target to fail during compilation")
+    }
+    catch (XetoCompilerErr err)
+    {
+      verify(err.msg.contains("Unresolved spec: Missing"), err.msg)
+    }
+  }
+
+  Void testMissingReferenceDoesNotExportTypeDefault()
+  {
+    rdf := export(
+      Str<|Target : Dict
+             Holder : Dict { targetRef: Ref<of:Target> }
+
+             @holder1: Holder {}|>)
+
+    holder := instanceBlock(rdf, "holder1")
+    verifyFalse(holder.contains("Holder.targetRef"), holder)
+  }
+
+  Void testLexicalSerialization()
+  {
+    rdf := export(
+      Str<|State : Enum {
+               unusual <key:"line\n\"quoted\"\\slash Ω">
+             }
+
+             Reading : Dict <doc:"line\n\"quoted\"\\slash Ω"> {
+               state: State
+               large: Int <minVal:-9223372036854775808, maxVal:9223372036854775807>
+               tiny: Number <minVal:1e-7, maxVal:1e20>
+               ratio: Float <minVal:1e-7, maxVal:1e20>
+               signedZero: Float
+               notANumber: Float
+               positiveInfinity: Float
+               negativeInfinity: Float
+             }
+
+             @reading1: Reading {
+               state: "line\n\"quoted\"\\slash Ω"
+               large: 9223372036854775807
+               tiny: 1e-7
+               ratio: 1e-7
+               signedZero: -0.0
+               notANumber: "NaN"
+               positiveInfinity: "INF"
+               negativeInfinity: "-INF"
+             }|>)
+
+    verify(rdf.contains("\"line\\n\\\"quoted\\\"\\\\slash Ω\"^^xsd:string"), rdf)
+    verify(rdf.contains("rdfs:comment \"line\\n\\\"quoted\\\"\\\\slash Ω\"@en"), rdf)
+    verify(rdf.contains("sh:minInclusive -9223372036854775808 ;"), rdf)
+    verify(rdf.contains("sh:maxInclusive 9223372036854775807 ;"), rdf)
+    verify(rdf.contains("sh:minInclusive \"1.0E-7\"^^xsd:double ;"), rdf)
+    verify(rdf.contains("sh:maxInclusive \"1.0E20\"^^xsd:double ;"), rdf)
+    verify(rdf.contains("\"1.0E-7\"^^xsd:double"), rdf)
+    verify(rdf.contains("sh:datatype xsd:double ;"), rdf)
+    verify(rdf.contains("sh:minInclusive \"1.0E-7\"^^xsd:double ;"), rdf)
+    verify(rdf.contains("sh:maxInclusive \"1.0E20\"^^xsd:double ;"), rdf)
+    verify(rdf.contains("\"1.0E-7\"^^xsd:double"), rdf)
+    verify(rdf.contains("\"-0.0\"^^xsd:double"), rdf)
+    verify(rdf.contains("\"NaN\"^^xsd:double"), rdf)
+    verify(rdf.contains("\"INF\"^^xsd:double"), rdf)
+    verify(rdf.contains("\"-INF\"^^xsd:double"), rdf)
+
+    controlRdf := export("Controlled : Dict <doc:\"backspace\\u0008 form-feed\\u000C control\\u0001\">")
+    verify(controlRdf.contains("rdfs:comment \"backspace\\b form-feed\\f control\\u0001\"@en"), controlRdf)
+
+    ns := createNamespace(["sys"])
+    sysVersion := ns.lib("sys").version
+    ["sys::tail.", "sys::name~one", "sys::op:name"].each |id|
+    {
+      instance := Etc.makeDict(["id":Ref(id), "spec":Ref("sys::Dict")])
+      buf := Buf()
+      RdfExporter(ns, buf.out, Etc.dict0).start.instance(instance).end
+      rendered := buf.flip.readAllStr
+      verify(rendered.contains("<http://xeto.dev/rdf/sys-${sysVersion}#"), rendered)
+    }
+  }
+
+  Void testNumberSpecialValuesUseDouble()
+  {
+    rdf := export(
+      "Reading : Dict { nan: Number, pos: Number, neg: Number }\n" +
+      "@reading1: Reading { nan: \"NaN\", pos: \"INF\", neg: \"-INF\" }")
+    verify(rdf.contains("\"NaN\"^^xsd:double"), rdf)
+    verify(rdf.contains("\"INF\"^^xsd:double"), rdf)
+    verify(rdf.contains("\"-INF\"^^xsd:double"), rdf)
+  }
+
+  Void testNaNFloatBoundFailsClosed()
+  {
+    verifyUnsupportedFragments(
+      "Reading : Dict { value: Float <minVal:\"NaN\"> }",
+      ["Invalid numeric metadata for", "Reading.value.minVal", "NaN is not an ordered bound"])
+  }
+
+  Void testListShapesAndInstances()
+  {
+    rdf := export(
+      Str<|Address : Dict { city: Str }
+
+             Batch : Dict {
+               names: List <of:Str, minSize:2, maxSize:3>
+               numbers: List <of:Number, nonEmpty>
+               addresses: List <of:Address>
+             }
+
+             @batch1: Batch {
+               names: {"alpha", "beta"}
+               numbers: {1, 2.5}
+               addresses: {
+                 Address { city: "Richmond" },
+                 Address { city: "Norfolk" }
+               }
+             }|>)
+
+    names := propertyShape(rdf, "Batch.names")
+    verify(names.contains("sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;"), names)
+    verify(names.contains("sh:datatype xsd:string ;"), names)
+    verify(rdf.contains("sh:path [ sh:zeroOrMorePath rdf:rest ] ;"), rdf)
+    verify(rdf.contains("sh:minCount 3 ;"), rdf)
+    verify(rdf.contains("sh:maxCount 4 ;"), rdf)
+
+    numbers := propertyShape(rdf, "Batch.numbers")
+    verify(numbers.contains("sh:datatype xsd:double ;"), numbers)
+    verify(rdf.contains("sh:minCount 2 ;"), rdf)
+
+    addresses := propertyShape(rdf, "Batch.addresses")
+    verify(addresses.contains("sh:class temp:Address ;"), addresses)
+
+    batch := instanceBlock(rdf, "batch1")
+    alpha := batch.index("\"alpha\"^^xsd:string")
+    beta  := batch.index("\"beta\"^^xsd:string")
+    verify(alpha != null && beta != null && alpha < beta, batch)
+    verify(batch.contains("\"1.0\"^^xsd:double"), batch)
+    verify(batch.contains("\"2.5\"^^xsd:double"), batch)
+    richmond := batch.index("\"Richmond\"^^xsd:string")
+    norfolk  := batch.index("\"Norfolk\"^^xsd:string")
+    verify(richmond != null && norfolk != null && richmond < norfolk, batch)
+  }
+
+  Void testQueryPropertyPaths()
+  {
+    rdf := export(
+      Str<|Equip : Dict {
+               points: Query<of:Point, inverse:"Point.equips">
+               plain: Query<of:Point>
+             }
+
+             Point : Dict {
+               equipRef: Ref<of:Equip>
+               equips: Query<of:Equip, via:"equipRef+">
+             }
+
+             @equip1: Equip {}
+             @point1: Point { equipRef: @equip1 }|>)
+
+    points := propertyShape(rdf, "[ sh:oneOrMorePath [ sh:inversePath temp:Point.equipRef ] ]")
+    verify(points.contains("sh:class temp:Point ;"), points)
+    verifyFalse(points.contains("sh:minCount"), points)
+    verifyFalse(points.contains("sh:maxCount"), points)
+
+    equips := propertyShape(rdf, "[ sh:oneOrMorePath temp:Point.equipRef ]")
+    verify(equips.contains("sh:class temp:Equip ;"), equips)
+    verifyFalse(equips.contains("sh:minCount"), equips)
+    verifyFalse(equips.contains("sh:maxCount"), equips)
+
+    plain := propertyShape(rdf, "Equip.plain")
+    verify(plain.contains("sh:class temp:Point ;"), plain)
+    verifyFalse(plain.contains("sh:minCount"), plain)
+    verifyFalse(plain.contains("sh:maxCount"), plain)
+
+    point := instanceBlock(rdf, "point1")
+    verify(point.contains("temp:Point.equipRef temp:equip1 ;"), point)
+    equip := instanceBlock(rdf, "equip1")
+    verifyFalse(equip.contains("temp:Equip.points"), equip)
+  }
+
+  Void testQueryPathValidation()
+  {
+    verifyUnsupportedFragments(
+      Str<|Point : Dict
+           Holder : Dict {
+             values: Query<of:Point, via:"pointRef", inverse:"Point.values">
+           }|>, ["Holder.values", "cannot declare both via and inverse"])
+
+    verifyUnsupportedFragments(
+      Str<|Point : Dict
+           Holder : Dict { values: Query<of:Point, via:""> }|>,
+      ["Empty query path", "Holder.values"])
+    verifyUnsupportedFragments(
+      Str<|Point : Dict
+           Holder : Dict { values: Query<of:Point, inverse:""> }|>,
+      ["Empty query path", "Holder.values"])
+
+    verifyUnsupportedFragments(
+      Str<|Point : Dict
+           Holder : Dict { values: Query<of:Point, via:"pointRef++"> }|>,
+      ["Invalid query path", "Holder.values", "pointRef++"])
+    verifyUnsupportedFragments(
+      Str<|Point : Dict
+           Holder : Dict {
+             values: Query<of:Point, inverse:"Point.equipRef+">
+           }|>, ["Invalid query path", "Holder.values", "Point.equipRef+"])
+
+    verifyUnsupportedFragments(
+      Str<|Equip : Dict {
+             points: Query<of:Point, inverse:"Point.equips">
+           }
+           Point : Dict { equips: Query<of:Equip> }|>,
+      ["Equip.points", "must reference a via query", "Point.equips"])
+
+    rdf := export(
+      Str<|Equip : Dict {
+               points: Query<of:Point, inverse:"Point.equipRef">
+             }
+             Point : Dict { equipRef: Ref<of:Equip, maybe> }|>)
+    direct := propertyShape(rdf, "[ sh:inversePath temp:Point.equipRef ]")
+    verify(direct.contains("sh:class temp:Point ;"), direct)
+  }
+
+  Void testUnsupportedListItemTypesFailClosed()
+  {
+    try
+    {
+      export(Str<|Color : Enum { red }
+                   Foo : Dict { colors: List <of:Color> }|>)
+      fail("Expected unsupported enum list item")
+    }
+    catch (UnsupportedErr err)
+    {
+      verify(err.msg.contains("Foo.colors: enum item type"), err.msg)
+      verify(err.msg.endsWith("::Color"), err.msg)
+    }
+
+    try
+    {
+      export(Str<|Foo : Dict { refs: List <of:Ref> }|>)
+      fail("Expected unsupported reference list item")
+    }
+    catch (UnsupportedErr err)
+    {
+      verify(err.msg.contains("Foo.refs: reference item type sys::Ref"), err.msg)
+    }
+  }
+
+  Void testUnitAndQuantityShapesAndInstances()
+  {
+    rdf := export(
+      Str<|Reading : Dict {
+               unit: Unit <quantity:"temperature">
+               percent: Number <unit:"%", minVal:0, maxVal:100>
+               power: Number <quantity:"power">
+               currency: Unit <quantity:"currency">
+             }
+
+             @reading1: Reading {
+               unit: Unit "°F"
+               percent: Number "50%"
+               power: Number "1kW"
+               currency: Unit "\$"
+             }|>)
+
+    verify(rdf.contains("sh:path temp:Reading.unit ;\n    sh:class qudt:Unit ;"), rdf)
+    verify(rdf.contains("sh:hasValue quantitykind:Temperature"), rdf)
+    verify(rdf.contains("sh:path temp:Reading.percent ;\n    sh:minCount 1 ;"), rdf)
+    verify(rdf.contains("sh:class qudt:QuantityValue ;"), rdf)
+    verify(rdf.contains("sh:path qudt:numericValue ;"), rdf)
+    verify(rdf.contains("sh:minInclusive \"0.0\"^^xsd:double ;"), rdf)
+    verify(rdf.contains("sh:maxInclusive \"100.0\"^^xsd:double ;"), rdf)
+    verify(rdf.contains("sh:path qudt:unit ;"), rdf)
+    verify(rdf.contains("sh:hasValue unit:PERCENT ;"), rdf)
+    verify(rdf.contains("sh:hasValue quantitykind:Power"), rdf)
+
+    reading := instanceBlock(rdf, "reading1")
+    verify(reading.contains("temp:Reading.unit unit:DEG_F ;"), reading)
+    verify(reading.contains("qudt:numericValue \"50.0\"^^xsd:double ;"), reading)
+    verify(reading.contains("qudt:unit unit:PERCENT"), reading)
+    verify(reading.contains("qudt:numericValue \"1.0\"^^xsd:double ;"), reading)
+    verify(reading.contains("qudt:unit unit:KiloW"), reading)
+    verify(reading.contains("temp:Reading.currency currency:USD ;"), reading)
+
+    // QUDT ontology facts are external validation inputs, not copied output.
+    verifyFalse(rdf.contains("unit:DEG_F a qudt:Unit"), rdf)
+    verifyFalse(rdf.contains("quantitykind:Temperature skos:broader"), rdf)
+  }
+
+  Void testUnmappedUnitFailsClosed()
+  {
+    verifyErrMsg(UnsupportedErr#, "No reviewed QUDT mapping for Xeto unit 'centum_cubic_feet_natural_gas'")
+    {
+      export(
+        Str<|Reading : Dict { unit: Unit }
+               @reading1: Reading { unit: Unit "Ccf_natural_gas" }|>)
+    }
+  }
+
   private Str export(Str src)
+  {
+    return exportWithOpts(src, Etc.dict0)
+  }
+
+  private Str exportWithOpts(Str src, Dict opts)
   {
     ns  := createNamespace(["sys"])
     lib := ns.compileTempLib(src)
     buf := Buf()
-    RdfExporter(ns, buf.out, Etc.dict0).start.lib(lib).end
+    RdfExporter(ns, buf.out, opts).start.lib(lib).end
     return buf.flip.readAllStr.replace(lib.name, "temp")
   }
 
   private Str propertyShape(Str rdf, Str property)
   {
-    path := "sh:path temp:${property} ;"
+    path := property.startsWith("[")
+      ? "sh:path ${property} ;"
+      : "sh:path temp:${property} ;"
     start := rdf.index(path)
     if (start == null) throw Err("Missing property shape for ${property}")
     close := "  ] ;"
     end := rdf.index(close, start)
     if (end == null) throw Err("Unterminated property shape for ${property}")
     return rdf[start..<(end + close.size)]
+  }
+
+  private Str instanceBlock(Str rdf, Str id)
+  {
+    start := rdf.index("temp:${id}\n")
+    if (start == null) throw Err("Missing instance ${id}")
+    end := rdf.index("\n.\n", start)
+    if (end == null) throw Err("Unterminated instance ${id}")
+    return rdf[start..<(end + 3)]
+  }
+
+  private Str resourceBlock(Str rdf, Str resource)
+  {
+    start := rdf.index("${resource}\n")
+    if (start == null) throw Err("Missing resource ${resource}")
+    end := rdf.index("\n.\n", start)
+    if (end == null) throw Err("Unterminated resource ${resource}")
+    return rdf[start..<(end + 3)]
+  }
+
+  private Void verifyUnsupported(Str src, Str expected)
+  {
+    try
+    {
+      export(src)
+      fail("Expected unsupported RDF mapping: ${src}")
+    }
+    catch (UnsupportedErr err)
+    {
+      verify(err.msg.contains(expected), err.msg)
+    }
+  }
+
+  private Void verifyUnsupportedFragments(Str src, Str[] expected)
+  {
+    try
+    {
+      export(src)
+      fail("Expected unsupported RDF mapping: ${src}")
+    }
+    catch (UnsupportedErr err)
+    {
+      expected.each |fragment| { verify(err.msg.contains(fragment), err.msg) }
+    }
   }
 
   private Int countMatches(Str source, Str match)
@@ -240,4 +1049,3 @@ class RdfTest : AbstractXetoTest
   private static const Regex qudtLocalName := Regex<|[A-Za-z_][A-Za-z0-9._-]*|>
 
 }
-

--- a/src/tool/xetoTools/fan/ExportRdf.fan
+++ b/src/tool/xetoTools/fan/ExportRdf.fan
@@ -13,6 +13,12 @@ using haystack
 
 internal class ExportRdf : ExportCmd
 {
+  @Opt { help = "Export native instances without schema and ontology triples" }
+  Bool instancesOnly
+
+  @Opt { help = "Export schema and ontology triples without native instances" }
+  Bool schemaOnly
+
   override Str cmdName() { "export-rdf" }
 
   override Str summary() { "Export Xeto to RDF" }
@@ -20,6 +26,8 @@ internal class ExportRdf : ExportCmd
   override Exporter initExporter(Namespace ns, OutStream out)
   {
     opts := Str:Obj[:]
+    if (instancesOnly) opts["instancesOnly"] = Marker.val
+    if (schemaOnly) opts["schemaOnly"] = Marker.val
     return RdfExporter(ns, out, Etc.makeDict(opts))
   }
 
@@ -28,4 +36,3 @@ internal class ExportRdf : ExportCmd
     t.toStr + ".ttl"
   }
 }
-


### PR DESCRIPTION
implement the supported Xeto-to-RDF mapping, including SHACL shapes, native instance projection, QUDT references, query paths, inherited constraints, mixins, globals, and fail-closed unsupported mappings.

add schema-only and instance-only export-rdf projections.